### PR TITLE
Fix the default godot-status (standard -> stable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This GitHub Action automates the execution of GdUnit4 unit tests within the Godo
 | Parameter      | Description                                              | Type   | Required | Default   |
 | -------------- | -------------------------------------------------------- | ------ | -------- | --------- |
 | godot-version  | The version of Godot in which the tests should be run.   | string | true     |           |
-| godot-status   | The Godot status (e.g., "standard", "rc1", "dev1").     | string | false    | standard  |
+| godot-status   | The Godot status (e.g., "stable", "rc1", "dev1").       | string | false    | stable    |
 | godot-net      | Set to true to run on Godot .Net version for C# tests.   | bool   | false    | false     |
 | version        | The version of GdUnit4 to use.                          | string | false    | latest    |
 | paths          | Comma-separated or newline-separated list of directories containing tests to execute. | string | true     |           |
@@ -37,8 +37,8 @@ A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run 
     # The version of Godot in which the tests should be run. (e.g., "4.2.1")
     godot-version: ''
     
-    # The Godot status (e.g., "standard", "rc1", "dev1")
-    # Default: standard
+    # The Godot status (e.g., "stable", "rc1", "dev1")
+    # Default: stable
     godot-status: ''
     
     # Set to true to run on Godot .Net version to run C# tests
@@ -68,7 +68,7 @@ A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run 
 ```
 
 ## Examples
-This example runs all tests located under `res://myproject/tests` on Godot-4.2.1-standard with the latest GdUnit4 release.
+This example runs all tests located under `res://myproject/tests` on Godot-4.2.1-stable with the latest GdUnit4 release.
 ```yaml
 - uses: actions/checkout@v4
 - uses: MikeSchulze/gdUnit4-action@v1

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ inputs:
     description: 'The version of Godot in which the tests should be run.'
     required: true
   godot-status:
-    description: 'The Godot status (e.g., "standard", "rc1", "dev1")'
+    description: 'The Godot status (e.g., "stable", "rc1", "dev1")'
     required: false
-    default: 'standard'
+    default: 'stable'
   godot-net:
     description: 'Set to true for Godot .Net (C#).'
     required: false


### PR DESCRIPTION
Godot's official releases use the suffix "stable", not "standard".

For example, https://github.com/godotengine/godot-builds/releases/tag/4.2.1-stable .