### PR TITLE
Add an option to keep the installed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This GitHub Action automates the execution of GdUnit4 unit tests within the Godo
 
 
 ### Note on Versioning:
-A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run on the latest release, use `latest`, and for the latest unreleased version, use `master`.
+A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run on the latest release, use `latest`, and for the latest unreleased version, use `master`. To keep the version installed in your project, use `installed`.
 
 
 ---

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,13 @@ runs:
     - name: 'Install gdUnit4 plugin - ${{ inputs.version }}'
       shell: bash
       run: |
+          if ${{ inputs.version == 'installed' }}; then
+            echo -e "\e[33m Info: Using the installed GdUnit4 plugin. \e[0m"
+            gdunit_version=$(grep -oP '^version="\K[^"]+' ./addons/gdUnit4/plugin.cfg)
+            echo "GDUNIT_VERSION=${gdunit_version}" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
           if [[ -d ./addons/gdUnit4 ]]; then
             echo -e "\e[33m Info: Found a previous installation of GdUnit4, deleting it now. \e[0m"
             rm -rf ./addons/gdUnit4


### PR DESCRIPTION
Setting `version: installed` will keep the version of gdUnit4 installed in the project already, instead of replacing it with a specific version.

This is useful to ensure consistency between the version used in local development and in CI/CD.