### PR TITLE
GD-15: The action should accept additional installed plugins

### DIFF
--- a/.gdunit4_action/publish-test-report/action.yml
+++ b/.gdunit4_action/publish-test-report/action.yml
@@ -17,3 +17,4 @@ runs:
         path: 'reports/**/results.xml'
         reporter: java-junit
         fail-on-error: 'false'
+        fail-on-empty: 'false'

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,8 @@ body:
       description: Which gdUnit4-action version are you using?
       options:
         - gdUnit4-action@master (Pre Release/Master branch)
-        - gdUnit4-action@v1.0.1 (Latest Release)
+        - gdUnit4-action@v1.0.2 (Latest Release)
+        - gdUnit4-action@v1.0.1
         - gdUnit4-action@v1
       default: 1
     validations:

--- a/.github/workflows/resources/addons/custom/plugin.cfg
+++ b/.github/workflows/resources/addons/custom/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="custom"
+description="just a example"
+author=""
+version=""
+script="plugin.gd"

--- a/.github/workflows/resources/addons/custom/plugin.gd
+++ b/.github/workflows/resources/addons/custom/plugin.gd
@@ -1,0 +1,10 @@
+@tool
+extends EditorPlugin
+
+
+func _enter_tree():
+	prints("_enter_tree")
+
+
+func _exit_tree():
+	prints("_exit_tree")

--- a/action.yml
+++ b/action.yml
@@ -109,8 +109,12 @@ runs:
 
           # Install requested gdUnit4 version
           echo -e "\e[34m Install GdUnit4 \e[92m${gdunit_version} \e[34mplugin in the project \e[0m"
-          mv ./.install-gdunit4/addons .
+          cp -R ./.install-gdunit4/addons/gdUnit4 ./addons/
           chmod +x ./addons/gdUnit4/runtest.sh
+          echo -e "\e[34m Installed plugins\e[0m"
+          echo -e "\e[34m -----------------\e[0m"
+          ls --color=auto -lsA ./addons
+          echo -e "\e[34m -----------------\e[0m"
 
     - name: 'Restore .Net Project'
       if: ${{ !cancelled() }}


### PR DESCRIPTION
# Why
The action is failing when additional plugins installed. We use the `mv` command to install get selected `gdUnit4` plugin  into addons folder, this will fail when the addons folder is not empty

# What
- use `cp` instead of `mv` command to copy the gdUnit4 plugin to the addons folder.
- Correction of the error when publishing reports if no reports are created


