### PR TITLE
GD-17: Fix failing action if no addons installed

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,8 @@ body:
       description: Which gdUnit4-action version are you using?
       options:
         - gdUnit4-action@master (Pre Release/Master branch)
-        - gdUnit4-action@v1.0.2 (Latest Release)
+        - gdUnit4-action@v1.0.3 (Latest Release)
+        - gdUnit4-action@v1.0.2
         - gdUnit4-action@v1.0.1
         - gdUnit4-action@v1
       default: 1

--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,8 @@ runs:
 
           # Install requested gdUnit4 version
           echo -e "\e[34m Install GdUnit4 \e[92m${gdunit_version} \e[34mplugin in the project \e[0m"
-          cp -R ./.install-gdunit4/addons/gdUnit4 ./addons/
+          mkdir -p ./addons/gdUnit4/
+          cp -R ./.install-gdunit4/addons/gdUnit4 ./addons
           chmod +x ./addons/gdUnit4/runtest.sh
           echo -e "\e[34m Installed plugins\e[0m"
           echo -e "\e[34m -----------------\e[0m"


### PR DESCRIPTION
# Why
The action is failing when no addons installed, the install plugin do copy to wrong destination

# What
- fix install gdUnit4 plugin by create the 'addons/gdUnit4' folder if not exists.

