### PR TITLE
Feature/Optional Upload Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This GitHub Action automates the execution of GdUnit4 unit tests within the Godo
 | arguments      | Additional arguments to pass to GdUnit4<br> see https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/. | string | false    |           |
 | timeout        | The test execution timeout in minutes.                  | int    | false    | 10        |
 | retries        | The number of retries if the tests fail.                | int    | false    | 0         |
-| upload-report | Whether to upload the report file & logs as an artifact | bool    | false    | true      |
+| upload-report | Whether to publish & upload the report file | bool    | false    | true      |
 | report-name    | The name of the test report file.                        | string | false    | test-report.xml |
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This GitHub Action automates the execution of GdUnit4 unit tests within the Godo
 | arguments      | Additional arguments to pass to GdUnit4<br> see https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/. | string | false    |           |
 | timeout        | The test execution timeout in minutes.                  | int    | false    | 10        |
 | retries        | The number of retries if the tests fail.                | int    | false    | 0         |
-| upload-report | Whether to publish & upload the report file | bool    | false    | true      |
+| upload-report  | Whether to publish & upload the report file             | bool   | false    | true      |
 | report-name    | The name of the test report file.                        | string | false    | test-report.xml |
 
 
@@ -107,6 +107,16 @@ In this example, all tests located in 'myproject1/tests' and 'myproject2/tests' 
       res://myproject1/tests
       res://myproject2/tests
     report-name: 'test-result.xml'
+```
+
+In this example, we run the tests but without a published test report.
+```yaml
+- uses: actions/checkout@v4
+- uses: MikeSchulze/gdUnit4-action@v1
+  with:
+    godot-version: '4.2.1'
+    paths: 'res://tests'
+    upload-report: false
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This GitHub Action automates the execution of GdUnit4 unit tests within the Godo
 | arguments      | Additional arguments to pass to GdUnit4<br> see https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/. | string | false    |           |
 | timeout        | The test execution timeout in minutes.                  | int    | false    | 10        |
 | retries        | The number of retries if the tests fail.                | int    | false    | 0         |
+| upload-report | Whether to upload the report file & logs as an artifact | bool    | false    | true      |
 | report-name    | The name of the test report file.                        | string | false    | test-report.xml |
 
 
@@ -52,19 +53,19 @@ A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run 
   with:
     # The version of Godot in which the tests should be run. (e.g., "4.2.1")
     godot-version: ''
-    
+
     # The Godot status (e.g., "stable", "rc1", "dev1")
     # Default: stable
     godot-status: ''
-    
+
     # Set to true to run on Godot .Net version to run C# tests
     # Default: false
     godot-net: ''
-    
+
     # The version of GdUnit4 to use. (e.g. "v4.2.0", "latest", "master").
     # Default: latest
     version: ''
-    
+
     # Comma-separated or newline-separated list of directories containing test to execute..
     paths: ''
 
@@ -73,9 +74,9 @@ A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run 
     timeout: ''
 
     # The number of retries if the tests fail. (This can be used for flaky test)
-    # Default: 0 
+    # Default: 0
     retries: ''
-    
+
     # Additional arguments to pass to GdUnit4 (see https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/).
     arguments: ''
 

--- a/action.yml
+++ b/action.yml
@@ -156,13 +156,13 @@ runs:
           await runTests(args, core);
 
     - name: 'Publish Unit Test Reports'
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && inputs.upload-report == 'true' }}
       uses: ./.gdunit4_action/publish-test-report
       with:
         report-name: ${{ inputs.report-name }}
 
     - name: 'Upload Unit Test Reports'
-      if: ${{ !cancelled() }} && ${{ inputs.upload-report == 'true' }}
+      if: ${{ !cancelled() && inputs.upload-report == 'true' }}
       uses: ./.gdunit4_action/upload-test-report
       with:
         report-name: ${{ inputs.report-name }}

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'The number of retries if the tests fail.'
     required: false
     default: '0'
+  upload-report:
+    description: 'Whether the report & logs should be uploaded.'
+    required: false
+    default: true
   report-name:
     description: 'The name of the test report file.'
     required: false
@@ -158,7 +162,7 @@ runs:
         report-name: ${{ inputs.report-name }}
 
     - name: 'Upload Unit Test Reports'
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() }} && ${{ inputs.upload-report == 'true' }}
       uses: ./.gdunit4_action/upload-test-report
       with:
         report-name: ${{ inputs.report-name }}


### PR DESCRIPTION
# Why
Added a new property to optionally upload a test report - sometimes uploading an artifact isn't always needed (and potentially useful to skip)

# What
- Added new table entry in documentation
- Added new clause to check against the new config property

