### PR TITLE
GD-21: Add support for custom project directory

### DIFF
--- a/.gdunit4_action/publish-test-report/action.yml
+++ b/.gdunit4_action/publish-test-report/action.yml
@@ -5,16 +5,19 @@ inputs:
   report-name:
     description: 'Name of the check run which will be created.'
     required: true
+  project_dir:
+    description: 'The working directory to collect the results.'
+    required: true
+    default: './'
 
 runs:
   using: composite
   steps:
-
     - name: 'Publish Test Results'
       uses: dorny/test-reporter@v1.8.0
       with:
         name: ${{ inputs.report-name }}
-        path: 'reports/**/results.xml'
+        path: '${{ inputs.project_dir }}reports/**/results.xml'
         reporter: java-junit
         fail-on-error: 'false'
         fail-on-empty: 'false'

--- a/.gdunit4_action/unit-test/index.js
+++ b/.gdunit4_action/unit-test/index.js
@@ -2,11 +2,11 @@ const pathLib = require("path");
 const { spawn, spawnSync } = require("node:child_process");
 
 
-function getProjectPath() {
+function getProjectPath(project_dir) {
   if (!process.env.GITHUB_WORKSPACE) {
     throw new Error("GITHUB_WORKSPACE environment variable not set");
   }
-  return pathLib.join(process.env.GITHUB_WORKSPACE, "./");
+  return pathLib.join(process.env.GITHUB_WORKSPACE, project_dir);
 }
 
 
@@ -26,7 +26,7 @@ function console_error(...args) {
 
 async function runTests(exeArgs, core) {
   try {
-    const { timeout, paths, arguments, retries } = exeArgs;
+    const { project_dir, timeout, paths, arguments, retries } = exeArgs;
     // Split by newline or comma, map, trim, and filter empty strings
     const pathsArray = paths.split(/[\r\n,]+/).map((entry) => entry.trim()).filter(Boolean);
     // verify support of multi paths/fixed since v4.2.1
@@ -48,13 +48,14 @@ async function runTests(exeArgs, core) {
       `${arguments}`
     ];
 
-    console_info(`Running GdUnit4 ${process.env.GDUNIT_VERSION} tests...`, getProjectPath(), args);
+    const working_dir = getProjectPath(project_dir);
+    console_info(`Running GdUnit4 ${process.env.GDUNIT_VERSION} tests...`, working_dir, args);
 
     let retriesCount = 0;
 
     while (retriesCount <= retries) {
       const child = spawnSync("xvfb-run", args, {
-        cwd: getProjectPath(),
+        cwd: working_dir,
         timeout: timeout * 1000 * 60,
         encoding: "utf-8",
         shell: true,

--- a/.gdunit4_action/upload-test-report/action.yml
+++ b/.gdunit4_action/upload-test-report/action.yml
@@ -5,6 +5,10 @@ inputs:
   report-name:
     description: 'Name of the report to be upload.'
     required: true
+  project_dir:
+    description: 'The working directory to collect the reports.'
+    required: true
+    default: './'
 
 runs:
   using: composite
@@ -15,6 +19,6 @@ runs:
         retention-days: 10
         name: artifact_${{ inputs.report-name }}
         path: |
-          reports/**
+          ${{ inputs.project_dir }}reports/**
           /var/lib/systemd/coredump/**
           /var/log/syslog

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mv -f .github/workflows/resources/* .
 
-      - name: 'Test gdUnit4-action@master: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}'
+      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}'
         if: ${{ matrix.godot-net == '' }}
         timeout-minutes: 5
         uses: ./
@@ -64,7 +64,7 @@ jobs:
           timeout: 2
           report-name: report_gdUnit4-${{ matrix.version }}_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}.xml
 
-      - name: 'Test gdUnit4-action@master: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
+      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
         if: ${{ matrix.godot-net == '.Net' }}
         timeout-minutes: 5
         uses: ./
@@ -77,6 +77,48 @@ jobs:
           timeout: 2
           retries: 3 # We have set the number of repetitions to 3 because Godot mono randomly crashes during C# tests
           report-name: report_gdUnit4-${{ matrix.version }}_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net.xml
+
+
+  unit-tests-custom-working-directory:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+
+    name: 'GdUnit4 action on custom working directory'
+
+    steps:
+      - name: 'Checkout gdUnit4-action'
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+  
+      - name: 'Install custom test project'
+        shell: bash
+        run: |
+          mv -f .github/workflows/custom_workpath/ ./custom_workpath/
+  
+      - name: 'Test gdUnit4-action: on custom project directory'
+        timeout-minutes: 5
+        uses: ./
+        with:
+          godot-version: 4.2.1
+          project_dir: './custom_workpath/'
+          paths: |
+            res://tests/
+          timeout: 2
+          report-name: report_gdUnit4-custom-working-directory.xml
+
+      - name: 'Test gdUnit4-action: on custom project directory C#'
+        timeout-minutes: 5
+        uses: ./
+        with:
+          godot-version: 4.2.1
+          godot-net: true
+          version: 'installed'
+          project_dir: './custom_workpath/'
+          paths: 'res://tests/'
+          timeout: 2
+          report-name: report_gdUnit4-custom-working-directory-net.xml
 
   # tests if the action reports test failures the action must fail
   action-fail-test:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           mv -f .github/workflows/resources/* .
 
-      - name: 'Test gdUnit4-action@master: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}'
+      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}'
         if: ${{ matrix.godot-net == '' }}
         timeout-minutes: 5
         uses: ./
@@ -63,7 +63,7 @@ jobs:
           timeout: 2
           report-name: report_gdUnit4-${{ matrix.version }}_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}.xml
 
-      - name: 'Test gdUnit4-action@master: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
+      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-status }}-net'
         if: ${{ matrix.godot-net == '.Net' }}
         timeout-minutes: 5
         uses: ./
@@ -76,6 +76,48 @@ jobs:
           timeout: 2
           retries: 3 # We have set the number of repetitions to 3 because Godot mono randomly crashes during C# tests
           report-name: report_gdUnit4-${{ matrix.version }}_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net.xml
+
+
+  unit-tests-custom-working-directory:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+
+    name: 'GdUnit4 action on custom working directory'
+
+    steps:
+      - name: 'Checkout gdUnit4-action'
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+  
+      - name: 'Install custom test project'
+        shell: bash
+        run: |
+          mv -f .github/workflows/custom_workpath/ ./custom_workpath/
+  
+      - name: 'Test gdUnit4-action: on custom project directory'
+        timeout-minutes: 5
+        uses: ./
+        with:
+          godot-version: 4.2.1
+          project_dir: './custom_workpath/'
+          paths: |
+            res://tests/
+          timeout: 2
+          report-name: report_gdUnit4-custom-working-directory.xml
+
+      - name: 'Test gdUnit4-action: on custom project directory C#'
+        timeout-minutes: 5
+        uses: ./
+        with:
+          godot-version: 4.2.1
+          godot-net: true
+          version: 'installed'
+          project_dir: './custom_workpath/'
+          paths: 'res://tests/'
+          timeout: 2
+          report-name: report_gdUnit4-custom-working-directory-net.xml
 
 
   # tests if the action reports test failures the action must fail

--- a/.github/workflows/custom_workpath/custom_workpath.csproj
+++ b/.github/workflows/custom_workpath/custom_workpath.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Godot.NET.Sdk/4.2.1">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <NoWarn>NU1605</NoWarn>
+    <RootNamespace>CustomProject</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--Required for GdUnit4-->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="gdUnit4.api" Version="4.2.*-*" />
+    <PackageReference Include="gdUnit4.test.adapter" Version="1.*-*" />
+  </ItemGroup>
+
+</Project>

--- a/.github/workflows/custom_workpath/project.godot
+++ b/.github/workflows/custom_workpath/project.godot
@@ -1,0 +1,24 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="custom_workpath"
+config/features=PackedStringArray("4.2", "C#", "GL Compatibility")
+config/icon="res://icon.svg"
+
+[dotnet]
+
+project/assembly_name="custom_workpath"
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"

--- a/.github/workflows/custom_workpath/tests/ExampleTest.cs
+++ b/.github/workflows/custom_workpath/tests/ExampleTest.cs
@@ -1,0 +1,16 @@
+namespace CustomProject.Tests;
+
+
+using GdUnit4;
+using static GdUnit4.Assertions;
+
+[TestSuite]
+public class ExampleTest
+{
+    [TestCase]
+    public void success()
+    {
+        AssertBool(true).IsTrue();
+    }
+
+}

--- a/.github/workflows/custom_workpath/tests/exampleTest.gd
+++ b/.github/workflows/custom_workpath/tests/exampleTest.gd
@@ -1,0 +1,4 @@
+extends GdUnitTestSuite
+
+func test_example() -> void:
+	assert_bool(true).is_true()

--- a/README.md
+++ b/README.md
@@ -1,19 +1,11 @@
 
----
-
 <h1 align="center">gdUnit4-action </h1>
 
 [![License](https://img.shields.io/github/license/MikeSchulze/gdunit4-action)](https://github.com/MikeSchulze/gdunit4-action/LICENSE)
 [![GitHub release badge](https://badgen.net/github/release/MikeSchulze/gdunit4-action/stable)](https://github.com/MikeSchulze/gdunit4-action/releases/latest)
 [![CI/CD](https://github.com/MikeSchulze/gdunit4-action/actions/workflows/ci-dev.yml/badge.svg)](https://github.com/MikeSchulze/gdunit4-action/actions/workflows/ci-dev.yml)
 
-
-
-
-
-
 This GitHub Action automates the execution of GdUnit4 unit tests within the Godot Engine 4.x environment.<br> It provides flexibility in configuring the Godot version, GdUnit4 version, test paths, and other parameters to suit your testing needs.
-
 
 * [Inputs](#inputs)
 * [Usage](#usage)
@@ -21,32 +13,32 @@ This GitHub Action automates the execution of GdUnit4 unit tests within the Godo
 * [License](#license)
 * [Contributing](#contribution-guidelines)
 
-
 ---
 
 ## Inputs
 
-| Parameter      | Description                                              | Type   | Required | Default   |
-| -------------- | -------------------------------------------------------- | ------ | -------- | --------- |
-| godot-version  | The version of Godot in which the tests should be run.   | string | true     |           |
-| godot-status   | The Godot status (e.g., "stable", "rc1", "dev1").       | string | false    | stable    |
-| godot-net      | Set to true to run on Godot .Net version for C# tests.   | bool   | false    | false     |
-| version        | The version of GdUnit4 to use.                          | string | false    | latest    |
+| Parameter      | Description                                                   | Type   | Required | Default   |
+| -------------- | ------------------------------------------------------------- | ------ | -------- | --------- |
+| godot-version  | The version of Godot in which the tests should be run.        | string | true     |           |
+| godot-status   | The Godot status (e.g., "stable", "rc1", "dev1").             | string | false    | stable    |
+| godot-net      | Set to true to run on Godot .Net version for C# tests.        | bool   | false    | false     |
+| version        | The version of GdUnit4 to use.                                | string | false    | latest    |
+| project_dir    | The project directory in which the action is to be executed.  | string | false    | ./        |
 | paths          | Comma-separated or newline-separated list of directories containing tests to execute. | string | true     |           |
-| arguments      | Additional arguments to pass to GdUnit4<br> see https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/. | string | false    |           |
-| timeout        | The test execution timeout in minutes.                  | int    | false    | 10        |
-| retries        | The number of retries if the tests fail.                | int    | false    | 0         |
-| upload-report  | Whether to publish & upload the report file             | bool   | false    | true      |
-| report-name    | The name of the test report file.                        | string | false    | test-report.xml |
+| arguments      | Additional arguments to pass to GdUnit4<br> see <https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/>. | string | false    |           |
+| timeout        | The test execution timeout in minutes.                        | int    | false    | 10        |
+| retries        | The number of retries if the tests fail.                      | int    | false    | 0         |
+| upload-report  | Whether to publish & upload the report file                   | bool   | false    | true      |
+| report-name    | The name of the test report file.                             | string | false    | test-report.xml |
 
+### Note on Versioning
 
-### Note on Versioning:
 A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run on the latest release, use `latest`, and for the latest unreleased version, use `master`. To keep the version installed in your project, use `installed`.
-
 
 ---
 
 ## Usage
+
 ```yaml
 
 - uses: MikeSchulze/gdUnit4-action@v1
@@ -61,6 +53,11 @@ A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run 
     # Set to true to run on Godot .Net version to run C# tests
     # Default: false
     godot-net: ''
+
+    # The project directory in which the action is to be executed.
+    # The specified directory must end with a path separator. e.g. ./MyProject/
+    # Default: './'
+    project_dir: ''
 
     # The version of GdUnit4 to use. (e.g. "v4.2.0", "latest", "master").
     # Default: latest
@@ -85,7 +82,9 @@ A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run 
 ```
 
 ## Examples
+
 This example runs all tests located under `res://myproject/tests` on Godot-4.2.1-stable with the latest GdUnit4 release.
+
 ```yaml
 - uses: actions/checkout@v4
 - uses: MikeSchulze/gdUnit4-action@v1
@@ -95,8 +94,8 @@ This example runs all tests located under `res://myproject/tests` on Godot-4.2.1
     report-name: 'test-result.xml'
 ```
 
-
 In this example, all tests located in 'myproject1/tests' and 'myproject2/tests' are executed using the master branch version of GdUnit4
+
 ```yaml
 - uses: actions/checkout@v4
 - uses: MikeSchulze/gdUnit4-action@v1
@@ -110,6 +109,7 @@ In this example, all tests located in 'myproject1/tests' and 'myproject2/tests' 
 ```
 
 In this example, we run the tests but without a published test report.
+
 ```yaml
 - uses: actions/checkout@v4
 - uses: MikeSchulze/gdUnit4-action@v1
@@ -119,20 +119,41 @@ In this example, we run the tests but without a published test report.
     upload-report: false
 ```
 
+In this example, we have a custom project structure and needs to setup the `project_dir`
+
+```bash
+- root/
+  - MyProject/
+  - MyProject/src
+  - MyProject/tests
+```
+
+```yaml
+- uses: actions/checkout@v4
+- uses: MikeSchulze/gdUnit4-action@v1
+  with:
+    godot-version: '4.2.1'
+    project_dir: './MyProject/'
+    paths: 'res://tests'
+    
+```
+
 ---
 
 ## License
+
 The scripts and documentation in this project are released under the [MIT License](./LICENSE)
 
 ---
 
-### You Are Welcome To:
-  * [Give Feedback](https://github.com/MikeSchulze/gdUnit4-action/discussions) on the gdUnit GitHub Discussions page.
-  * [Suggest Improvements](https://github.com/MikeSchulze/gdUnit4-action/issues/new?assignees=MikeSchulze&labels=enhancement&template=feature_request.md&title=) by creating a new feature request issue on the gdUnit GitHub Issues page.
-  * [Report Bugs](https://github.com/MikeSchulze/gdUnit4-action/issues/new?assignees=MikeSchulze&labels=bug&projects=projects%2F5&template=bug_report.yml&title=GD-XXX%3A+Describe+the+issue+briefly)  by creating a new bug report issue on the gdUnit GitHub Issues page.
+### You Are Welcome To
 
+* [Give Feedback](https://github.com/MikeSchulze/gdUnit4-action/discussions) on the gdUnit GitHub Discussions page.
+* [Suggest Improvements](https://github.com/MikeSchulze/gdUnit4-action/issues/new?assignees=MikeSchulze&labels=enhancement&template=feature_request.md&title=) by creating a new feature request issue on the gdUnit GitHub Issues page.
+* [Report Bugs](https://github.com/MikeSchulze/gdUnit4-action/issues/new?assignees=MikeSchulze&labels=bug&projects=projects%2F5&template=bug_report.yml&title=GD-XXX%3A+Describe+the+issue+briefly)  by creating a new bug report issue on the gdUnit GitHub Issues page.
 
 ---
+
 ### Contribution Guidelines
 
 **Thank you for your interest in contributing to GdUnit4!**<br>
@@ -145,8 +166,6 @@ Using GitHub Issues: We utilize GitHub issues for tracking feature requests and 
 We value your input and appreciate your contributions to make gdunit4-action even better!
 
 ---
-
-
 
 ## Contributors
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: latest
   paths:
-    description: 'Comma-separated or newline-separated list of directorys containing test to execute.'
+    description: 'Comma-separated or newline-separated list of directories containing test to execute.'
     required: true
   arguments:
     description: 'Additional arguments to run GdUnit4. (e.g. "--verbose")'
@@ -35,7 +35,11 @@ inputs:
   upload-report:
     description: 'Whether the report & logs should be uploaded.'
     required: false
-    default: true
+    default: 'true'
+  project_dir:
+    description: 'The project directory in which the action is to be executed. The specified directory must end with a path separator. e.g. ./MyProject/'
+    required: false
+    default: './'
   report-name:
     description: 'The name of the test report file.'
     required: false
@@ -84,6 +88,8 @@ runs:
     - name: 'Install gdUnit4 plugin - ${{ inputs.version }}'
       shell: bash
       run: |
+        echo -e "\e[33m Change to project directory: ${{ inputs.project_dir }} \e[0m"
+        cd "${{ inputs.project_dir }}"
         if ${{ inputs.version == 'installed' }}; then
           echo -e "\e[33m Info: Using the installed GdUnit4 plugin. \e[0m"
           gdunit_version="v$(grep -oP '^version="\K[^"]+' ./addons/gdUnit4/plugin.cfg)"
@@ -125,6 +131,7 @@ runs:
       shell: bash
       run: |
         if ${{ inputs.godot-net == 'true' }}; then
+          cd "${{ inputs.project_dir }}"
           dotnet restore
           dotnet build
         fi
@@ -135,6 +142,7 @@ runs:
         GODOT_BIN: '/home/runner/godot-linux/godot'
       shell: bash
       run: |
+        cd "${{ inputs.project_dir }}"
         echo -e "\e[94mStart of the recovery of the project cache ...\e[0m"
         $GODOT_BIN --path ./ -e --headless --quit-after 2000
         echo -e "\e[94mProject cache successfully restored.\e[0m"
@@ -148,9 +156,10 @@ runs:
         script: |
           const { runTests } = require('./.gdunit4_action/unit-test/index.js')
           const args = {
-            timeout: '${{ inputs.timeout }}',
+            project_dir: `${{ inputs.project_dir }}`,
             paths: `${{ inputs.paths }}`,
             arguments: `${{ inputs.arguments }}`,
+            timeout: ${{ inputs.timeout }},
             retries: ${{ inputs.retries }}
           };
           await runTests(args, core);
@@ -159,10 +168,12 @@ runs:
       if: ${{ !cancelled() && inputs.upload-report == 'true' }}
       uses: ./.gdunit4_action/publish-test-report
       with:
+        project_dir: ${{ inputs.project_dir }}
         report-name: ${{ inputs.report-name }}
 
     - name: 'Upload Unit Test Reports'
       if: ${{ !cancelled() && inputs.upload-report == 'true' }}
       uses: ./.gdunit4_action/upload-test-report
       with:
+        project_dir: ${{ inputs.project_dir }}
         report-name: ${{ inputs.report-name }}


### PR DESCRIPTION
# Why
A project can be build under a specific directory and the action must run in this directory to install the gdUnit4 plugin and run the tests.

# What
- add new property `project_dir` to setup custom project directory to run
- added custom project to the ci-dev for testing the new property


