### PR TITLE
GD-26: Use `gdunit4.test.adapter` to run C# tests

### DIFF
--- a/.gdunit4_action/.runsettings
+++ b/.gdunit4_action/.runsettings
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+    <RunConfiguration>
+        <MaxCpuCount>1</MaxCpuCount>
+        <ResultsDirectory>./TestResults</ResultsDirectory>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TestSessionTimeout>180000</TestSessionTimeout>
+        <TreatNoTestsAsError>true</TreatNoTestsAsError>
+    </RunConfiguration>
+
+    <LoggerRunSettings>
+        <Loggers>
+            <Logger friendlyName="console" enabled="True">
+                <Configuration>
+                    <Verbosity>detailed</Verbosity>
+                </Configuration>
+            </Logger>
+            <Logger friendlyName="html" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.html</LogFileName>
+                </Configuration>
+            </Logger>
+            <Logger friendlyName="trx" enabled="True">
+                <Configuration>
+                    <LogFileName>test-result.trx</LogFileName>
+                </Configuration>
+            </Logger>
+        </Loggers>
+    </LoggerRunSettings>
+
+    <GdUnit4>
+        <!-- Additonal Godot runtime parameters-->
+        <Parameters></Parameters>
+        <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
+             This likely determines how the test names are displayed in the test results.-->
+        <DisplayName>FullyQualifiedName</DisplayName>
+    </GdUnit4>
+</RunSettings>

--- a/.gdunit4_action/.runsettings
+++ b/.gdunit4_action/.runsettings
@@ -30,7 +30,8 @@
 
     <GdUnit4>
         <!-- Additonal Godot runtime parameters-->
-        <Parameters></Parameters>
+        <!-- These parameters are crucial for configuring the Godot runtime to work in headless environments, such as those used in automated testing or CI/CD pipelines.-->
+        <Parameters>--audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --verbose</Parameters>
         <!-- Controlls the Display name attribute of the TestCase. Allowed values are SimpleName and FullyQualifiedName.
              This likely determines how the test names are displayed in the test results.-->
         <DisplayName>FullyQualifiedName</DisplayName>

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.1.3', '4.2', '4.2.1']
+        godot-version: ['4.1.3', '4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['', '-net']
-        version: ['master', 'latest', 'v4.2.0']
+        version: ['master', 'latest', 'v4.2.2']
 
     steps:
       - uses: actions/checkout@v4
@@ -40,8 +40,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: MikeSchulze/gdUnit4-action
           run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
-      - run: |
-            ls -lsR ./
 
       - name: 'Publish Test Results'
         uses: dorny/test-reporter@v1.9.0
@@ -50,7 +48,9 @@ jobs:
           # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363 
           # We do the download manually on step `Download artifacts`
           #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
-          path: './home/runner/work/gdUnit4-action/gdUnit4-action/reports/**/results.xml'
+          path: |
+            './home/runner/work/gdUnit4-action/gdUnit4-action/reports/**/results.xml'
+            './home/runner/work/gdUnit4-action/gdUnit4-action/reports/*.xml'
           reporter: java-junit
           fail-on-error: 'false'
           fail-on-empty: 'false'

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         godot-version: ['4.1.3', '4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
-        godot-net: ['', '-net']
+        godot-net: ['', '.Net']
         version: ['master', 'latest', 'v4.2.2']
 
     steps:
@@ -45,22 +45,21 @@ jobs:
         if: ${{ matrix.godot-net == '' }}
         uses: dorny/test-reporter@v1.9.0
         with:
-          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}
           # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363 
           # We do the download manually on step `Download artifacts`
           #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
           path: |
             './home/runner/work/gdUnit4-action/gdUnit4-action/reports/**/results.xml'
-            './home/runner/work/gdUnit4-action/gdUnit4-action/reports/*.xml'
           reporter: java-junit
           fail-on-error: 'false'
           fail-on-empty: 'false'
       
-      - name: 'Publish Test Results'
-        if: ${{ matrix.godot-net == '-net' }}
+      - name: 'Publish Test Adapter Results'
+        if: ${{ matrix.godot-net == '.Net' }}
         uses: dorny/test-reporter@v1.9.0
         with:
-          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}-net
           # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363 
           # We do the download manually on step `Download artifacts`
           #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -26,7 +26,7 @@ jobs:
         godot-version: ['4.1.3', '4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['', '.Net']
-        version: ['master', 'latest', 'v4.2.2']
+        version: ['master', 'latest', 'v4.2.0']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -42,6 +42,7 @@ jobs:
           run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
 
       - name: 'Publish Test Results'
+        if: ${{ matrix.godot-net == '' }}
         uses: dorny/test-reporter@v1.9.0
         with:
           name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
@@ -52,5 +53,19 @@ jobs:
             './home/runner/work/gdUnit4-action/gdUnit4-action/reports/**/results.xml'
             './home/runner/work/gdUnit4-action/gdUnit4-action/reports/*.xml'
           reporter: java-junit
+          fail-on-error: 'false'
+          fail-on-empty: 'false'
+      
+      - name: 'Publish Test Results'
+        if: ${{ matrix.godot-net == '-net' }}
+        uses: dorny/test-reporter@v1.9.0
+        with:
+          name: report_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363 
+          # We do the download manually on step `Download artifacts`
+          #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.godot-net }}
+          path: |
+            './home/runner/work/gdUnit4-action/gdUnit4-action/reports/*.xml'
+          reporter: dotnet-trx
           fail-on-error: 'false'
           fail-on-empty: 'false'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.1.3', '4.2', '4.2.1']
+        godot-version: ['4.1.3', '4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['', '.Net']
-        version: ['master', 'latest', 'v4.2.0']
+        version: ['master', 'latest', 'v4.2.2']
 
     permissions:
       actions: read

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,7 +26,7 @@ jobs:
         godot-version: ['4.1.3', '4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['', '.Net']
-        version: ['master', 'latest', 'v4.2.5']
+        version: ['master', 'latest', 'v4.2.0']
 
     permissions:
       actions: read

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -26,7 +26,7 @@ jobs:
         godot-version: ['4.1.3', '4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['', '.Net']
-        version: ['master', 'latest', 'v4.2.2']
+        version: ['master', 'latest', 'v4.2.5']
 
     permissions:
       actions: read

--- a/.github/workflows/resources/test.csproj
+++ b/.github/workflows/resources/test.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!--Required for GdUnit4-->
-    <PackageReference Include="gdUnit4.api" Version="4.2.0-rc*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="gdUnit4.api" Version="4.2.*" />
+    <PackageReference Include="gdUnit4.test.adapter" Version="1.*" />
   </ItemGroup>
 </Project>

--- a/.github/workflows/resources/test.csproj
+++ b/.github/workflows/resources/test.csproj
@@ -10,8 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!--Required for GdUnit4-->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="gdUnit4.api" Version="4.2.*" />
-    <PackageReference Include="gdUnit4.test.adapter" Version="1.*" />
   </ItemGroup>
 </Project>

--- a/action.yml
+++ b/action.yml
@@ -140,8 +140,8 @@ runs:
         # install required packages
         dotnet add package Microsoft.NET.Test.Sdk
         # for gdunit version less than 4.2.2 we need to load api version 4.2.1.1
-        gdUnitVersion="${{ inputs.version#v }}"
-        if (( $(echo "$gdUnitVersion < v4.2.2" | bc -l) )); then
+        gdUnitVersion=$(echo "${{ inputs.version }}" | sed 's/^v//')
+        if [[ $(echo "$gdUnitVersion < 4.2.2" | bc -l) == 1 ]]; then
           echo "gdUnit4 version $gdUnitVersion less than 4.2.2, update project to gdUnit4.api v4.2.1.1"
           dotnet add package gdUnit4.api --version 4.2.1.1
         else

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,12 @@ runs:
         cd "${{ inputs.project_dir }}"
         # install required packages
         dotnet add package Microsoft.NET.Test.Sdk
-        dotnet add package gdUnit4.api
+        # for gdunit version less than 4.2.2 we need to load api version 4.2.1.1
+        if (( $(echo "${{ inputs.version }} < 4.2.2" | bc -l) )); then
+          dotnet add package gdUnit4.api --version 4.2.1.1
+        else
+          dotnet add package gdUnit4.api
+        fi
         dotnet add package gdUnit4.test.adapter
         dotnet restore
         dotnet build

--- a/action.yml
+++ b/action.yml
@@ -137,6 +137,10 @@ runs:
       shell: bash
       run: |
         cd "${{ inputs.project_dir }}"
+        # install required packages
+        dotnet add package Microsoft.NET.Test.Sdk
+        dotnet add package gdUnit4.api
+        dotnet add package gdUnit4.test.adapter
         dotnet restore
         dotnet build
 

--- a/action.yml
+++ b/action.yml
@@ -141,6 +141,7 @@ runs:
         dotnet add package Microsoft.NET.Test.Sdk
         # for gdunit version less than 4.2.2 we need to load api version 4.2.1.1
         if (( $(echo "${{ inputs.version }} < 4.2.2" | bc -l) )); then
+          echo "gdUnit4 version less than 4.2.2, update project to gdUnit4.api v4.2.1.1"
           dotnet add package gdUnit4.api --version 4.2.1.1
         else
           dotnet add package gdUnit4.api

--- a/action.yml
+++ b/action.yml
@@ -180,7 +180,7 @@ runs:
           echo "Found `.runsettings` file."
         else
           echo "No project specific '.runsettings' found, using action default '.runsettings'"
-          cp /home/runner/.gdunit4_action/.runsettings .
+          cp $GITHUB_ACTION_PATH/.gdunit4_action/.runsettings .
         fi
         xvfb-run --auto-servernum dotnet test --no-build --settings .runsettings --results-directory ./reports --logger "trx;LogFileName=results.xml"
 

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
         echo "GDUNIT_VERSION=${gdunit_version}" >> "$GITHUB_ENV"
         echo "Checkout GdUnit4 from branch '${gdunit_version}'"
         # We need to check if we running on a forked GdUnit4 repository
-        if [ "${{ github.repository_owner }}" != "MikeSchulze"] && [ "${{ github.repository }}" == "${{ github.repository_owner }}/gdUnit4" ]; then
+        if [ "${{ github.repository_owner }}" != "MikeSchulze" ] && [ "${{ github.repository }}" == "${{ github.repository_owner }}/gdUnit4" ]; then
           echo -e "\e[34m Workflow is running on a forked GdUnit4 repository. \e[0m"
           git clone --quiet --depth 1 --branch ${gdunit_version} --single-branch https://github.com/${{ github.repository_owner }}/gdUnit4 ./.install-gdunit4
         else

--- a/action.yml
+++ b/action.yml
@@ -182,11 +182,7 @@ runs:
           echo "No project specific '.runsettings' found, using action default '.runsettings'"
           cp ./.gdunit4_action/.runsettings .
         fi
-        ls -lsa ./
-        dotnet test --settings .runsettings --list-tests
-        dotnet test --settings .runsettings --results-directory ./reports --logger "trx;LogFileName=results.xml" -v n
-        ls -lsa ./
-        ls -lsR ./reports
+        xvfb-run --auto-servernum dotnet test --no-build --settings .runsettings --results-directory ./reports --logger "trx;LogFileName=results.xml"
 
     - name: 'Publish Unit Test Reports'
       if: ${{ !cancelled() && inputs.publish-report == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
         # install required packages
         dotnet add package Microsoft.NET.Test.Sdk
         # for gdunit version less than 4.2.2 we need to load api version 4.2.1.1
-        if (( $(echo "${{ inputs.version }} < 4.2.2" | bc -l) )); then
+        if (( $(echo "${{ inputs.version }} < v4.2.2" | bc -l) )); then
           echo "gdUnit4 version less than 4.2.2, update project to gdUnit4.api v4.2.1.1"
           dotnet add package gdUnit4.api --version 4.2.1.1
         else

--- a/action.yml
+++ b/action.yml
@@ -180,7 +180,7 @@ runs:
           echo "Found `.runsettings` file."
         else
           echo "No project specific '.runsettings' found, using action default '.runsettings'"
-          cp ./.gdunit4_action/.runsettings .
+          cp /home/runner/.gdunit4_action/.runsettings .
         fi
         xvfb-run --auto-servernum dotnet test --no-build --settings .runsettings --results-directory ./reports --logger "trx;LogFileName=results.xml"
 

--- a/action.yml
+++ b/action.yml
@@ -140,8 +140,9 @@ runs:
         # install required packages
         dotnet add package Microsoft.NET.Test.Sdk
         # for gdunit version less than 4.2.2 we need to load api version 4.2.1.1
-        if (( $(echo "${{ inputs.version }} < v4.2.2" | bc -l) )); then
-          echo "gdUnit4 version less than 4.2.2, update project to gdUnit4.api v4.2.1.1"
+        gdUnitVersion="${{ inputs.version#v }}"
+        if (( $(echo "$gdUnitVersion < v4.2.2" | bc -l) )); then
+          echo "gdUnit4 version $gdUnitVersion less than 4.2.2, update project to gdUnit4.api v4.2.1.1"
           dotnet add package gdUnit4.api --version 4.2.1.1
         else
           dotnet add package gdUnit4.api

--- a/action.yml
+++ b/action.yml
@@ -140,14 +140,15 @@ runs:
         # install required packages
         dotnet add package Microsoft.NET.Test.Sdk
         # for gdunit version less than 4.2.2 we need to load api version 4.2.1.1
-        gdUnitVersion=$(echo "${{ inputs.version }}" | sed 's/^v//')
-        if [[ $(echo "$gdUnitVersion < 4.2.2" | bc -l) == 1 ]]; then
-          echo "gdUnit4 version $gdUnitVersion less than 4.2.2, update project to gdUnit4.api v4.2.1.1"
-          dotnet add package gdUnit4.api --version 4.2.1.1
+        gdUnitVersion=$(echo "${{ inputs.version }}" | sed 's/^v//; s/\.//g')
+        if [[ ${gdUnitVersion} < 422 ]]; then
+          echo "gdUnit4 version ${gdUnitVersion} less 4.2.2, update project to gdUnit4.api v4.2.1"
+          dotnet add package gdUnit4.api --version 4.2.1
+          dotnet add package gdUnit4.test.adapter --version 1.0.0
         else
           dotnet add package gdUnit4.api
+          dotnet add package gdUnit4.test.adapter
         fi
-        dotnet add package gdUnit4.test.adapter
         dotnet restore
         dotnet build
 

--- a/action.yml
+++ b/action.yml
@@ -134,14 +134,12 @@ runs:
         echo -e "\e[34m -----------------\e[0m"
 
     - name: 'Restore .Net Project'
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && inputs.godot-net == 'true' }}
       shell: bash
       run: |
-        if ${{ inputs.godot-net == 'true' }}; then
-          cd "${{ inputs.project_dir }}"
-          dotnet restore
-          dotnet build
-        fi
+        cd "${{ inputs.project_dir }}"
+        dotnet restore
+        dotnet build
 
     - name: 'Restore Godot project cache'
       if: ${{ !cancelled() }}
@@ -154,8 +152,8 @@ runs:
         $GODOT_BIN --path ./ -e --headless --quit-after 2000
         echo -e "\e[94mProject cache successfully restored.\e[0m"
 
-    - name: 'Run Tests'
-      if: ${{ !cancelled() }}
+    - name: 'Run GDScript Tests'
+      if: ${{ !cancelled() && inputs.godot-net == 'false' }}
       env:
         GODOT_BIN: '/home/runner/godot-linux/godot'
       uses: actions/github-script@v7
@@ -170,6 +168,26 @@ runs:
             retries: ${{ inputs.retries }}
           };
           await runTests(args, core);
+
+    - name: 'Run C# Tests'
+      if: ${{ !cancelled() && inputs.godot-net == 'true' }}
+      env:
+        GODOT_BIN: '/home/runner/godot-linux/godot'
+      shell: bash
+      run: |
+        cd "${{ inputs.project_dir }}"
+        # test if a .runsettings file exists, if not use the action provided default .runsettings
+        if [ -f .runsettings ]; then
+          echo "Found `.runsettings` file."
+        else
+          echo "No project specific '.runsettings' found, using action default '.runsettings'"
+          cp ./.gdunit4_action/.runsettings .
+        fi
+        ls -lsa ./
+        dotnet test --settings .runsettings --list-tests
+        dotnet test --settings .runsettings --results-directory ./reports --logger "trx;LogFileName=results.xml" -v n
+        ls -lsa ./
+        ls -lsR ./reports
 
     - name: 'Publish Unit Test Reports'
       if: ${{ !cancelled() && inputs.upload-report == 'true' }}


### PR DESCRIPTION
# Why
With the `gdunit.test.adaper` we can direct run the tests via `dotnet test`

# What
- `Added step `Run C# Tests`
- check `godot-net` to decide between GDScript or C# step


