### PR TITLE
Allow to disable the report publishing

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -168,6 +168,38 @@ jobs:
           exit 1
           
 
+  # tests do not build the report
+  test-disable-report:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    permissions:
+      actions: read
+      contents: read
+    name: 'GdUnit4 action without report generation'
+
+    steps:
+      - name: 'Checkout gdUnit4-action'
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: 'Install test project'
+        shell: bash
+        run: |
+          mv -f .github/workflows/resources/* .
+
+      - name: 'Run failing failing test'
+        timeout-minutes: 3
+        uses: ./
+        with:
+          godot-version: 4.2.1
+          paths: |
+            res://tests/
+          publish-report: 'false'
+          report-name: artifact_action_create-report_false
+
+
   finalize:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,19 +17,20 @@ This GitHub Action automates the execution of GdUnit4 unit tests within the Godo
 
 ## Inputs
 
-| Parameter      | Description                                                   | Type   | Required | Default   |
-| -------------- | ------------------------------------------------------------- | ------ | -------- | --------- |
-| godot-version  | The version of Godot in which the tests should be run.        | string | true     |           |
-| godot-status   | The Godot status (e.g., "stable", "rc1", "dev1").             | string | false    | stable    |
-| godot-net      | Set to true to run on Godot .Net version for C# tests.        | bool   | false    | false     |
-| version        | The version of GdUnit4 to use.                                | string | false    | latest    |
-| project_dir    | The project directory in which the action is to be executed.  | string | false    | ./        |
+| Parameter      | Description                                                                           | Type   | Required | Default   |
+| -------------- | ------------------------------------------------------------------------------------- | ------ | -------- | --------- |
+| godot-version  | The version of Godot in which the tests should be run.                                | string | true     |           |
+| godot-status   | The Godot status (e.g., "stable", "rc1", "dev1").                                     | string | false    | stable    |
+| godot-net      | Set to true to run on Godot .Net version for C# tests.                                | bool   | false    | false     |
+| version        | The version of GdUnit4 to use.                                                        | string | false    | latest    |
+| project_dir    | The project directory in which the action is to be executed.                          | string | false    | ./        |
 | paths          | Comma-separated or newline-separated list of directories containing tests to execute. | string | true     |           |
 | arguments      | Additional arguments to pass to GdUnit4<br> see <https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/>. | string | false    |           |
-| timeout        | The test execution timeout in minutes.                        | int    | false    | 10        |
-| retries        | The number of retries if the tests fail.                      | int    | false    | 0         |
-| upload-report  | Whether to publish & upload the report file                   | bool   | false    | true      |
-| report-name    | The name of the test report file.                             | string | false    | test-report.xml |
+| timeout        | The test execution timeout in minutes.                                                | int    | false    | 10        |
+| retries        | The number of retries if the tests fail.                                              | int    | false    | 0         |
+| publish-report | Enable disable to publish the report. To disable to run on forked repositories.       | bool   | false    | true      |
+| upload-report  | Enables/Disables to upload the report file                                            | bool   | false    | true      |
+| report-name    | The name of the test report file.                                                     | string | false    | test-report.xml |
 
 ### Note on Versioning
 
@@ -76,6 +77,14 @@ A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run 
 
     # Additional arguments to pass to GdUnit4 (see https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/).
     arguments: ''
+
+    # Enables/Disables to publish the report. To disable to run on forked repositories.
+    # Default: true
+    publish-report: ''
+
+    # Enables/Disables to upload the report file
+    # Default: true
+    upload-report: ''
 
     # The name of the test report file.
     report-name: ''

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'The number of retries if the tests fail.'
     required: false
     default: '0'
+  publish-report:
+    description: 'Enable disable to publish the report. To disable to run on forked repositories.'
+    required: false
+    default: 'true'
   upload-report:
     description: 'Whether the report & logs should be uploaded.'
     required: false
@@ -166,7 +170,7 @@ runs:
           await runTests(args, core);
 
     - name: 'Publish Unit Test Reports'
-      if: ${{ !cancelled() && inputs.upload-report == 'true' }}
+      if: ${{ !cancelled() && inputs.publish-report == 'true' }}
       uses: ./.gdunit4_action/publish-test-report
       with:
         project_dir: ${{ inputs.project_dir }}


### PR DESCRIPTION
# Why
We need according to the documentation of the `dorny/test-reporter` an option to disable report publishing, it could fail on forked branches. See https://github.com/dorny/test-reporter?tab=readme-ov-file#recommended-setup-for-public-repositories

# What
Added a new argument `publish-report` to control the report will be published.

