### PR TITLE
GD-36: Fixes action fails with permission denied error when using an installed version 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,6 +98,7 @@ runs:
           echo -e "\e[33m Info: Using the installed GdUnit4 plugin. \e[0m"
           gdunit_version="v$(grep -oP '^version="\K[^"]+' ./addons/gdUnit4/plugin.cfg)"
           echo "GDUNIT_VERSION=${gdunit_version}" >> "$GITHUB_ENV"
+          chmod +x ./addons/gdUnit4/runtest.sh
           exit 0
         fi
 


### PR DESCRIPTION
# Why
the script exited at the 'Install gdUnit4 plugin - ${{ inputs.version }}' step when using an installed version without granting executable permission to the ./addons/gdUnit4/runtest.sh file
causing xvfb-run throws permission denied error
by adding a step to grant permission manually, this issue can be resolved
but in my humble opinion, it's a good idea to prevent users from encountering this type of gotcha

the workflow i'm using for reference:
```yaml
name: "GDUnit4 CI action test"

on: workflow_dispatch

jobs:
  execute-gdunit:
    name: Run GDUnit4 tests
    runs-on: ubuntu-latest
    permissions:
      actions: write
      checks: write
      contents: write
      pull-requests: write
      statuses: write
    steps:
      - uses: actions/checkout@v4
      - name: "set permission"
        shell: 'bash'
        run: |
          chmod +x ./addons/gdUnit4/runtest.sh
      - uses: MikeSchulze/gdUnit4-action@v1.0.5
        with:
          godot-version: '4.2'
          godot-status: 'stable'
          version: 'installed'
          paths: 'res://tests'
```

# What
Add chmod command to grant executable permission to the runtest.sh file.

#36 