### PR TITLE
GD-40: Add property to enforce running GDScript test with Godot Mono executable

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.2', '4.2.1']
+        godot-version: ['4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['', '.Net']
         version: ['latest']
@@ -106,7 +106,7 @@ jobs:
         timeout-minutes: 5
         uses: ./
         with:
-          godot-version: 4.2.1
+          godot-version: 4.2.2
           project_dir: './custom_workpath/'
           paths: |
             res://tests/
@@ -122,13 +122,50 @@ jobs:
         timeout-minutes: 5
         uses: ./
         with:
-          godot-version: 4.2.1
+          godot-version: 4.2.2
           godot-net: true
           version: 'installed'
           project_dir: './custom_workpath/'
           paths: 'res://tests/'
           timeout: 2
           report-name: gdUnit4-custom-working-directory-net
+
+
+  # run gdscript tests with using Godot Mono executable
+  unit-tests-force-godot-mono:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    permissions:
+      actions: read
+      contents: read
+      checks: write
+      pull-requests: write
+      statuses: write
+    name: 'GdUnit4 action with force run Godot Mono'
+
+    steps:
+      - name: 'Checkout gdUnit4-action'
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+  
+      - name: 'Install custom test project'
+        shell: bash
+        run: |
+          mv -f .github/workflows/resources/* .
+  
+      - name: 'Test gdUnit4-action: force run Godot Mono'
+        timeout-minutes: 5
+        uses: ./
+        with:
+          godot-version: 4.2.2
+          godot-force-mono : 'true'
+          paths: |
+            res://tests/
+          timeout: 2
+          report-name: gdUnit4-force-mono
+
 
   # tests if the action reports test failures the action must fail
   action-fail-test:
@@ -162,7 +199,7 @@ jobs:
           GDUNIT_FAIL: 'true'
         uses: ./
         with:
-          godot-version: 4.2.1
+          godot-version: 4.2.2
           paths: |
             res://tests/
           timeout: 2
@@ -178,7 +215,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     name: 'Final Results'
-    needs: [unit-tests, action-fail-test]
+    needs: [unit-tests, unit-tests-force-godot-mono, unit-tests-custom-working-directory, action-fail-test]
     steps:
       - run: exit 1
         if: >-

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.1.3', '4.2', '4.2.1', '4.2.2']
+        godot-version: ['4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['', '.Net']
         version: ['master', 'latest', 'v4.2.0']
@@ -105,7 +105,7 @@ jobs:
         timeout-minutes: 5
         uses: ./
         with:
-          godot-version: 4.2.1
+          godot-version: 4.2.2
           project_dir: './custom_workpath/'
           paths: |
             res://tests/
@@ -117,7 +117,7 @@ jobs:
         timeout-minutes: 5
         uses: ./
         with:
-          godot-version: 4.2.1
+          godot-version: 4.2.2
           godot-net: true
           version: 'installed'
           project_dir: './custom_workpath/'
@@ -125,6 +125,43 @@ jobs:
           timeout: 2
           publish-report: false
           report-name: gdUnit4-custom-working-directory-net
+
+
+  # run gdscript tests with using Godot Mono executable
+  unit-tests-force-godot-mono:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    permissions:
+      actions: read
+      contents: read
+      checks: write
+      pull-requests: write
+      statuses: write
+    name: 'GdUnit4 action with force run Godot Mono'
+
+    steps:
+      - name: 'Checkout gdUnit4-action'
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+  
+      - name: 'Install custom test project'
+        shell: bash
+        run: |
+          mv -f .github/workflows/resources/* .
+  
+      - name: 'Test gdUnit4-action: force run Godot Mono'
+        id: test-force-mono
+        timeout-minutes: 5
+        uses: ./
+        with:
+          godot-version: 4.2.2
+          godot-force-mono : 'true'
+          paths: |
+            res://tests/
+          timeout: 2
+          report-name: gdUnit4-force-mono
 
 
   # tests if the action reports test failures the action must fail
@@ -159,7 +196,7 @@ jobs:
           GDUNIT_FAIL: 'true'
         uses: ./
         with:
-          godot-version: 4.2.1
+          godot-version: 4.2.2
           paths: |
             res://tests/
           timeout: 2
@@ -198,7 +235,7 @@ jobs:
         timeout-minutes: 3
         uses: ./
         with:
-          godot-version: 4.2.1
+          godot-version: 4.2.2
           paths: |
             res://tests/
           publish-report: false
@@ -208,7 +245,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     name: 'Final Results'
-    needs: [unit-tests, action-fail-test]
+    needs: [unit-tests, unit-tests-custom-working-directory, unit-tests-force-godot-mono, action-fail-test]
     steps:
       - run: exit 1
         if: >-

--- a/README.md
+++ b/README.md
@@ -17,20 +17,21 @@ This GitHub Action automates the execution of GdUnit4 unit tests within the Godo
 
 ## Inputs
 
-| Parameter      | Description                                                                           | Type   | Required | Default   |
-| -------------- | ------------------------------------------------------------------------------------- | ------ | -------- | --------- |
-| godot-version  | The version of Godot in which the tests should be run.                                | string | true     |           |
-| godot-status   | The Godot status (e.g., "stable", "rc1", "dev1").                                     | string | false    | stable    |
-| godot-net      | Set to true to run on Godot .Net version for C# tests.                                | bool   | false    | false     |
-| version        | The version of GdUnit4 to use.                                                        | string | false    | latest    |
-| project_dir    | The project directory in which the action is to be executed.                          | string | false    | ./        |
-| paths          | Comma-separated or newline-separated list of directories containing tests to execute. | string | true     |           |
-| arguments      | Additional arguments to pass to GdUnit4<br> see <https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/>. | string | false    |           |
-| timeout        | The test execution timeout in minutes.                                                | int    | false    | 10        |
-| retries        | The number of retries if the tests fail.                                              | int    | false    | 0         |
-| publish-report | Enable disable to publish the report. To disable to run on forked repositories.       | bool   | false    | true      |
-| upload-report  | Enables/Disables to upload the report file                                            | bool   | false    | true      |
-| report-name    | The name of the test report file.                                                     | string | false    | test-report.xml |
+| Parameter        | Description                                                                           | Type   | Required | Default   |
+| --------------   | ------------------------------------------------------------------------------------- | ------ | -------- | --------- |
+| godot-version    | The version of Godot in which the tests should be run.                                | string | true     |           |
+| godot-status     | The Godot status (e.g., "stable", "rc1", "dev1").                                     | string | false    | stable    |
+| godot-net        | Set to true to run on Godot .Net version for C# tests.                                | bool   | false    | false     |
+| godot-force-mono | Set to true to enforce running GDScript test with Godot Mono executable               | bool   | false    | false     |
+| version          | The version of GdUnit4 to use.                                                        | string | false    | latest    |
+| project_dir      | The project directory in which the action is to be executed.                          | string | false    | ./        |
+| paths            | Comma-separated or newline-separated list of directories containing tests to execute. | string | true     |           |
+| arguments        | Additional arguments to pass to GdUnit4<br> see <https://mikeschulze.github.io/gdUnit4/advanced_testing/cmd/>. | string | false    |           |
+| timeout          | The test execution timeout in minutes.                                                | int    | false    | 10        |
+| retries          | The number of retries if the tests fail.                                              | int    | false    | 0         |
+| publish-report   | Enable disable to publish the report. To disable to run on forked repositories.       | bool   | false    | true      |
+| upload-report    | Enables/Disables to upload the report file                                            | bool   | false    | true      |
+| report-name      | The name of the test report file.                                                     | string | false    | test-report.xml |
 
 ### Note on Versioning
 
@@ -54,6 +55,10 @@ A GdUnit4 **version** should be specified as a string, such as `v4.2.1`. To run 
     # Set to true to run on Godot .Net version to run C# tests
     # Default: false
     godot-net: ''
+
+    # Set to true to force running GDScript tests by using the Godot Mono executable
+    # Default: false
+    godot-force-mono: ''
 
     # The project directory in which the action is to be executed.
     # The specified directory must end with a path separator. e.g. ./MyProject/

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Set to true for Godot .Net (C#).'
     required: false
     default: 'false'
+  godot-force-mono:
+    description: 'Force test run to use Godot Mono version'
+    required: false
+    default: 'false'
   version:
     description: 'The version of GdUnit4 to use. (e.g. "v4.2.0", "latest", "master").'
     required: false
@@ -65,11 +69,13 @@ runs:
     - name: 'Set Cache Name'
       shell: bash
       run: |
-        if ${{inputs.godot-net == 'true'}}; then
+        if ${{inputs.godot-net == 'true' || inputs.godot-force-mono == 'true'}}; then
             echo "CACHE_NAME=${{ runner.OS }}-Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status }}_NET" >> "$GITHUB_ENV"
         else
             echo "CACHE_NAME=${{ runner.OS }}-Godot_v${{ inputs.godot-version }}-${{ inputs.godot-status }}" >> "$GITHUB_ENV"
         fi
+
+        echo "RUN_GDSCRIPT_TESTS=${{inputs.godot-net == 'false'}}" >> "$GITHUB_ENV"
 
     - name: 'Build Cache'
       uses: actions/cache@v4
@@ -123,7 +129,7 @@ runs:
         fi
 
         # Install requested gdUnit4 version
-        echo -e "\e[34m Install GdUnit4 \e[92m${gdunit_version} \e[34mplugin in the project \e[0m"
+        echo -e "\e[34m Install GdUnit4 \e[92m${gdunit_version} \e[34m plugin in the project \e[0m"
         mkdir -p ./addons/gdUnit4/
         cp -R ./.install-gdunit4/addons/gdUnit4 ./addons
         chmod +x ./addons/gdUnit4/runtest.sh
@@ -133,7 +139,7 @@ runs:
         echo -e "\e[34m -----------------\e[0m"
 
     - name: 'Restore .Net Project'
-      if: ${{ !cancelled() && inputs.godot-net == 'true' }}
+      if: ${{ !cancelled() && (inputs.godot-net == 'true' || inputs.godot-force-mono == 'true')}}
       shell: bash
       run: |
         cd "${{ inputs.project_dir }}"
@@ -165,7 +171,7 @@ runs:
 
     ## GDScript test run
     - name: 'Run GDScript Tests'
-      if: ${{ !cancelled() && inputs.godot-net == 'false' }}
+      if: ${{ !cancelled() && env.RUN_GDSCRIPT_TESTS == 'true'}}
       env:
         GODOT_BIN: '/home/runner/godot-linux/godot'
       uses: actions/github-script@v7
@@ -182,7 +188,7 @@ runs:
           await runTests(args, core);
 
     - name: 'Publish GDScript Unit Test Reports'
-      if: ${{ !cancelled() && inputs.publish-report == 'true' && inputs.godot-net == 'false'}}
+      if: ${{ !cancelled() && inputs.publish-report == 'true' && env.RUN_GDSCRIPT_TESTS == 'true'}}
       uses: ./.gdunit4_action/publish-test-report
       with:
         project_dir: ${{ inputs.project_dir }}
@@ -191,7 +197,7 @@ runs:
 
     ## .Net test run
     - name: 'Run C# Tests'
-      if: ${{ !cancelled() && inputs.godot-net == 'true' }}
+      if: ${{ !cancelled() && env.RUN_GDSCRIPT_TESTS == 'false' }}
       env:
         GODOT_BIN: '/home/runner/godot-linux/godot'
       shell: bash
@@ -207,7 +213,7 @@ runs:
         xvfb-run --auto-servernum dotnet test --no-build --settings .runsettings --results-directory ./reports --logger "trx;LogFileName=results.xml" -- GdUnit4.Parameters="--audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0"
 
     - name: 'Publish .Net Unit Test Reports'
-      if: ${{ !cancelled() && inputs.publish-report == 'true' && inputs.godot-net == 'true'}}
+      if: ${{ !cancelled() && inputs.publish-report == 'true' && env.RUN_GDSCRIPT_TESTS == 'false' }}
       uses: ./.gdunit4_action/publish-test-report
       with:
         project_dir: ${{ inputs.project_dir }}


### PR DESCRIPTION
# Why

see https://github.com/MikeSchulze/gdUnit4-action/issues/40

# What
- Added new optional property ` godot-force-mono` to enforce running GDScript tests by using the Godot Mono executable
