### PR TITLE
GD-45: Fix action cache to store Godot version when using `godot-force-mono` to force run with Godot Mono

### DIFF
--- a/.gdunit4_action/godot-install/action.yml
+++ b/.gdunit4_action/godot-install/action.yml
@@ -1,13 +1,13 @@
 name: install-godot-binary
-description: "Installs the Godot Runtime"
+description: 'Installs the Godot Runtime'
 
 inputs:
   godot-version:
-    description: "The Godot engine version"
+    description: 'The Godot engine version'
     type: string
     required: true
   godot-status-version:
-    description: "The Godot engine status version"
+    description: 'The Godot engine status version'
     type: string
     required: true
   godot-net:
@@ -21,8 +21,7 @@ inputs:
 runs:
   using: composite
   steps:
-
-    - name: "Download and Install Godot ${{ inputs.godot-version }}-${{ inputs.godot-status-version }}"
+    - name: 'Download and Install Godot ${{ inputs.godot-version }}-${{ inputs.godot-status-version }}'
       if: steps.godot-cache-binary.outputs.cache-hit != 'true'
       continue-on-error: false
       shell: bash
@@ -42,6 +41,7 @@ runs:
         fi
 
         GODOT_PACKAGE=$GODOT_BIN.zip
+        echo "Download URL: $DOWNLOAD_URL/$GODOT_PACKAGE"
         wget --progress=bar:force:noscroll $DOWNLOAD_URL/$GODOT_PACKAGE -P ${{ inputs.install-path }}
         unzip ${{ inputs.install-path }}/$GODOT_PACKAGE -d ${{ inputs.install-path }}
         rm -rf ${{ inputs.install-path }}/$GODOT_PACKAGE

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -28,7 +28,7 @@ jobs:
         godot-version: ['4.2', '4.2.1', '4.2.2']
         godot-status: ['stable']
         godot-net: ['', '.Net']
-        version: ['latest']
+        version: ['master', 'latest']
 
     permissions:
       actions: read

--- a/action.yml
+++ b/action.yml
@@ -91,9 +91,14 @@ runs:
       uses: ./.gdunit4_action/godot-install
       with:
         godot-version: ${{ inputs.godot-version }}
-        godot-net: ${{ inputs.godot-net }}
+        godot-net: ${{inputs.godot-net == 'true' || inputs.godot-force-mono == 'true'}}
         godot-status-version: ${{ inputs.godot-status }}
         install-path: '/home/runner/godot-linux'
+
+    - name: 'print restored version - ${{ inputs.version }}'
+      shell: bash
+      run: |
+        /home/runner/godot-linux/godot --version
 
     - name: 'Install gdUnit4 plugin - ${{ inputs.version }}'
       shell: bash


### PR DESCRIPTION
# Why
There is a bug to store the action cache when using `godot-force-mono = true` without set `godot-net = true`
This results into store the standard Godot version under the `Linux-Godot_vx.x.x-stable_NET` cache key

# What
Do evaluate both `godot-net` and `godot-force-mono` is set to true to install the right Godot version from the cache
