### PR TITLE
Update CI to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -37,7 +37,7 @@ jobs:
       pull-requests: write
       statuses: write
 
-    name: GdUnit4 '${{ matrix.version }}' - Godot_${{ matrix.godot-version }}-${{ matrix.godot-net }}
+    name: 'GdUnit4 ${{ matrix.version }} on Godot_${{ matrix.godot-version }} ${{ matrix.godot-net }}'
 
     steps:
       - name: 'Checkout gdUnit4-action'
@@ -82,7 +82,7 @@ jobs:
 
 
   unit-tests-custom-working-directory:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     permissions:
@@ -135,7 +135,7 @@ jobs:
 
   # run gdscript tests with using Godot .Net executable
   unit-tests-force-godot-mono:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     permissions:
@@ -173,7 +173,7 @@ jobs:
 
   # tests if the action reports test failures the action must fail
   action-fail-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     permissions:

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         godot-version: ['4.2', '4.2.1', '4.2.2', '4.3']
         godot-status: ['stable']
-        godot-net: ['', '-net']
+        godot-net: ['', 'net7.0', 'net8.0']
         version: ['master', 'latest', 'v4.2.0']
 
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -81,7 +81,7 @@ jobs:
           report-name: gdUnit4_${{ matrix.version }}_Godot${{ matrix.godot-version }}${{ matrix.godot-net }}
 
   unit-tests-custom-working-directory:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     permissions:
@@ -131,7 +131,7 @@ jobs:
 
   # run gdscript tests with using Godot Net executable
   unit-tests-force-godot-mono:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     permissions:
@@ -170,7 +170,7 @@ jobs:
 
   # tests if the action reports test failures the action must fail
   action-fail-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     permissions:
@@ -216,7 +216,7 @@ jobs:
 
   # tests do not build the report
   test-disable-report:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     permissions:

--- a/action.yml
+++ b/action.yml
@@ -144,15 +144,16 @@ runs:
         echo -e "\e[34m -----------------\e[0m"
 
     - name: 'Restore .Net Project'
-      if: ${{ !cancelled() && (inputs.godot-net == 'true' || inputs.godot-force-mono == 'true')}}
+      if: ${{ !cancelled() && (inputs.godot-net == 'true' || inputs.godot-force-mono == 'true') }}
       shell: bash
       run: |
         cd "${{ inputs.project_dir }}"
-        # install required packages
-        dotnet add package Microsoft.NET.Test.Sdk
+         
+        dotnet add package Microsoft.NET.Test.Sdk --version 17.9.0
         # for gdunit version less than 4.2.2 we need to load api version 4.2.1.1
         gdUnitVersion=$(echo "${{ inputs.version }}" | sed 's/^v//; s/\.//g')
         if [[ ${gdUnitVersion} < 422 ]]; then
+          # install required packages
           echo "gdUnit4 version ${gdUnitVersion} less 4.2.2, update project to gdUnit4.api v4.2.1"
           dotnet add package gdUnit4.api --version 4.2.1
           dotnet add package gdUnit4.test.adapter --version 1.0.0
@@ -160,8 +161,11 @@ runs:
           dotnet add package gdUnit4.api
           dotnet add package gdUnit4.test.adapter
         fi
+        
+        dotnet --version
         dotnet restore
         dotnet build
+        dotnet list package
 
     - name: 'Restore Godot project cache'
       if: ${{ !cancelled() }}


### PR DESCRIPTION
# Why
Ubuntu 22.04 is deprecated


# What
- update ci to Ubuntu 24.04
- add verbose installed SDK and packages
