### PR TITLE
GD-55: Handle action fails on master branch using Godot version less than 4.3

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}'
         if: ${{ matrix.godot-net == '' }}
+        id: test-action
+        continue-on-error: true
         timeout-minutes: 5
         uses: ./
         with:
@@ -62,6 +64,17 @@ jobs:
           publish-report: false
           report-name: gdUnit4_${{ matrix.version }}_Godot${{ matrix.godot-version }}${{ matrix.godot-net }}
 
+      - name: 'Verify used Godot version if failed'
+        if: ${{ steps.test-action.outcome == 'failure'}}
+        shell: bash
+        run: |
+          if [[ "${{ matrix.version }}" == "master" && "${{ matrix.godot-version }}" < "4.3" ]]; then
+            echo "The test should fail for master version on Godot < 4.3, to not report as error" 
+          else
+            echo "Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }} failed."
+            exit 1
+          fi
+        
       - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.godot-net }}'
         if: ${{ matrix.godot-net != '' }}
         env:

--- a/.github/workflows/resources/tests/gdunitExampleTest.gd
+++ b/.github/workflows/resources/tests/gdunitExampleTest.gd
@@ -1,55 +1,55 @@
 extends GdUnitTestSuite
 
 
-func before():
-	assert_failure(func(): assert_int(10).is_equal(42)) \
+func before() -> void:
+	assert_failure(func() -> void: assert_int(10).is_equal(42)) \
 		.is_failed() \
 		.has_line(5) \
 		.has_message("Expecting:\n '42'\n but was\n '10'")
 
 
-func after():
-	assert_failure(func(): assert_int(10).is_equal(42)) \
+func after() -> void:
+	assert_failure(func() -> void: assert_int(10).is_equal(42)) \
 		.is_failed() \
 		.has_line(12) \
 		.has_message("Expecting:\n '42'\n but was\n '10'")
 
 
-func before_test():
-	assert_failure(func(): assert_int(10).is_equal(42)) \
+func before_test() -> void:
+	assert_failure(func() -> void: assert_int(10).is_equal(42)) \
 		.is_failed() \
 		.has_line(19) \
 		.has_message("Expecting:\n '42'\n but was\n '10'")
 
 
-func after_test():
-	assert_failure(func(): assert_int(10).is_equal(42)) \
+func after_test() -> void:
+	assert_failure(func() -> void: assert_int(10).is_equal(42)) \
 		.is_failed() \
 		.has_line(26) \
 		.has_message("Expecting:\n '42'\n but was\n '10'")
 
 
-func test_get_line_number():
+func test_get_line_number() -> void:
 	# test to return the current line number for an failure
-	assert_failure(func(): assert_int(10).is_equal(42)) \
+	assert_failure(func() -> void: assert_int(10).is_equal(42)) \
 		.is_failed() \
 		.has_line(34) \
 		.has_message("Expecting:\n '42'\n but was\n '10'")
 
 
-func test_get_line_number_yielded():
+func test_get_line_number_yielded() -> void:
 	# test to return the current line number after using yield
 	await get_tree().create_timer(0.100).timeout
-	assert_failure(func(): assert_int(10).is_equal(42)) \
+	assert_failure(func() -> void: assert_int(10).is_equal(42)) \
 		.is_failed() \
 		.has_line(43) \
 		.has_message("Expecting:\n '42'\n but was\n '10'")
 
 
-func test_get_line_number_multiline():
+func test_get_line_number_multiline() -> void:
 	# test to return the current line number for an failure
 	# https://github.com/godotengine/godot/issues/43326
-	assert_failure(func(): assert_int(10)\
+	assert_failure(func() -> void: assert_int(10)\
 			.is_not_negative()\
 			.is_equal(42)) \
 		.is_failed() \
@@ -57,58 +57,60 @@ func test_get_line_number_multiline():
 		.has_message("Expecting:\n '42'\n but was\n '10'")
 
 
-func test_get_line_number_verify():
-	var obj = mock(RefCounted)
-	assert_failure(func(): verify(obj, 1).get_reference_count()) \
+@warning_ignore("unsafe_method_access")
+func test_get_line_number_verify() -> void:
+	var obj: RefCounted = mock(RefCounted)
+	assert_failure(func() -> void: verify(obj, 1).get_reference_count()) \
 		.is_failed() \
-		.has_line(62) \
+		.has_line(63) \
 		.has_message("Expecting interaction on:\n	'get_reference_count()'	1 time's\nBut found interactions on:\n")
 
 
-func test_is_null():
+func test_is_null() -> void:
 	assert_that(null).is_null()
-	
-	assert_failure(func(): assert_that(Color.RED).is_null()) \
+
+	assert_failure(func() -> void: assert_that(Color.RED).is_null()) \
 		.is_failed() \
-		.has_line(71) \
+		.has_line(72) \
 		.starts_with_message("Expecting: '<null>' but was 'Color(1, 0, 0, 1)'")
 
 
-func test_is_not_null():
+func test_is_not_null() -> void:
 	assert_that(Color.RED).is_not_null()
-	
-	assert_failure(func(): assert_that(null).is_not_null()) \
+
+	assert_failure(func() -> void: assert_that(null).is_not_null()) \
 		.is_failed() \
-		.has_line(80) \
+		.has_line(81) \
 		.has_message("Expecting: not to be '<null>'")
 
 
-func test_is_equal():
+func test_is_equal() -> void:
 	assert_that(Color.RED).is_equal(Color.RED)
 	assert_that(Plane.PLANE_XY).is_equal(Plane.PLANE_XY)
-	
-	assert_failure(func(): assert_that(Color.RED).is_equal(Color.GREEN)) \
+
+	assert_failure(func() -> void: assert_that(Color.RED).is_equal(Color.GREEN)) \
 		.is_failed() \
-		.has_line(90) \
+		.has_line(91) \
 		.has_message("Expecting:\n 'Color(0, 1, 0, 1)'\n but was\n 'Color(1, 0, 0, 1)'")
 
 
-func test_is_not_equal():
+func test_is_not_equal() -> void:
 	assert_that(Color.RED).is_not_equal(Color.GREEN)
 	assert_that(Plane.PLANE_XY).is_not_equal(Plane.PLANE_XZ)
-	
-	assert_failure(func(): assert_that(Color.RED).is_not_equal(Color.RED)) \
+
+	assert_failure(func() -> void: assert_that(Color.RED).is_not_equal(Color.RED)) \
 		.is_failed() \
-		.has_line(100) \
+		.has_line(101) \
 		.has_message("Expecting:\n 'Color(1, 0, 0, 1)'\n not equal to\n 'Color(1, 0, 0, 1)'")
 
 
+@warning_ignore("unsafe_method_access")
 func test_override_failure_message() -> void:
-	assert_failure(func(): assert_that(Color.RED) \
+	assert_failure(func() -> void: assert_that(Color.RED) \
 			.override_failure_message("Custom failure message") \
 			.is_null()) \
 		.is_failed() \
-		.has_line(107) \
+		.has_line(109) \
 		.has_message("Custom failure message")
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub release badge](https://badgen.net/github/release/MikeSchulze/gdunit4-action/stable)](https://github.com/MikeSchulze/gdunit4-action/releases/latest)
 [![CI/CD](https://github.com/MikeSchulze/gdunit4-action/actions/workflows/ci-dev.yml/badge.svg)](https://github.com/MikeSchulze/gdunit4-action/actions/workflows/ci-dev.yml)
 
-This GitHub Action automates the execution of GdUnit4 unit tests within the Godot Engine 4.x environment.<br> It provides flexibility in configuring the Godot version, GdUnit4 version, test paths, and other parameters to suit your testing needs.
+This GitHub Action automates the execution of GdUnit4 and GdUnit4Net unit tests within the Godot Engine 4.x environment.<br> It provides flexibility in configuring the Godot version, GdUnit4 version, test paths, and other parameters to suit your testing needs.
 
 * [Inputs](#inputs)
 * [Usage](#usage)

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'GdUnit4 - Test Runner Action'
 description: 'This GitHub Action automates the execution of GdUnit4 unit tests within the Godot Engine 4.x environment.'
-author: Mike Schulze <mikeschulze.lpz@kabelmail.de>
+author: Mike Schulze <mikeschulze.lpz@gmail.com>
 
 inputs:
   godot-version:


### PR DESCRIPTION

# Why
see https://github.com/MikeSchulze/gdUnit4-action/issues/55

# What
- Added a validation after the test run to check if the test fails on the master branch with a Godot version lower than 4.3 and end it as successful.

