### PR TITLE
Do not install the gdUnit4 plugin for the use of .NET actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,6 +105,8 @@ runs:
         /home/runner/godot-linux/godot --version
 
     - name: 'Install gdUnit4 plugin - ${{ inputs.version }}'
+      # We only install the plugin if required, for c# test is not need to install the plugin
+      if: ${{ !cancelled() && env.RUN_GDSCRIPT_TESTS == 'true' }}
       shell: bash
       run: |
         echo -e "\e[33m Change to project directory: ${{ inputs.project_dir }} \e[0m"


### PR DESCRIPTION
# Why
The plugin is only required to execute GDScript tests and not need for a pure .NET project.

# What
Do only install the GdUnit4 plugin for GDScript test execution
