### PR TITLE
Add Godot4.4 to execution matrix

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.2', '4.2.1', '4.2.2', '4.3']
+        godot-version: ['4.2', '4.2.1', '4.2.2', '4.3', '4.4']
         godot-status: ['stable']
         dotnet-version: ['', 'net7.0', 'net8.0']
         version: ['master', 'latest']

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.2', '4.2.1', '4.2.2', '4.3']
+        godot-version: ['4.2', '4.2.1', '4.2.2', '4.3', '4.4']
         godot-status: ['stable']
         dotnet-version: ['', 'net7.0', 'net8.0']
         gdunit-version: ['master', 'latest', 'v4.2.0']

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        godot-version: ['4.2', '4.2.1', '4.2.2', '4.3']
+        godot-version: ['4.2', '4.2.1', '4.2.2', '4.3', '4.4']
         godot-status: ['stable']
         dotnet-version: ['', 'net7.0', 'net8.0']
         version: ['master', 'latest', 'v4.2.0']

--- a/.github/workflows/resources/tests/gdunitExampleTest.gd
+++ b/.github/workflows/resources/tests/gdunitExampleTest.gd
@@ -72,7 +72,7 @@ func test_is_null() -> void:
 	assert_failure(func() -> void: assert_that(Color.RED).is_null()) \
 		.is_failed() \
 		.has_line(72) \
-		.starts_with_message("Expecting: '<null>' but was 'Color(1, 0, 0, 1)'")
+		.starts_with_message("Expecting: '<null>' but was 'Color%s'" % Color.RED)
 
 
 func test_is_not_null() -> void:
@@ -91,7 +91,7 @@ func test_is_equal() -> void:
 	assert_failure(func() -> void: assert_that(Color.RED).is_equal(Color.GREEN)) \
 		.is_failed() \
 		.has_line(91) \
-		.has_message("Expecting:\n 'Color(0, 1, 0, 1)'\n but was\n 'Color(1, 0, 0, 1)'")
+		.has_message("Expecting:\n 'Color%s'\n but was\n 'Color%s'" % [Color.GREEN, Color.RED])
 
 
 func test_is_not_equal() -> void:
@@ -101,7 +101,7 @@ func test_is_not_equal() -> void:
 	assert_failure(func() -> void: assert_that(Color.RED).is_not_equal(Color.RED)) \
 		.is_failed() \
 		.has_line(101) \
-		.has_message("Expecting:\n 'Color(1, 0, 0, 1)'\n not equal to\n 'Color(1, 0, 0, 1)'")
+		.has_message("Expecting:\n 'Color%s'\n not equal to\n 'Color%s'" % [Color.RED, Color.RED])
 
 
 @warning_ignore("unsafe_method_access")


### PR DESCRIPTION
# What
- Add Godot4.4 to execution matrix
- Fix failing tests based on formatting changes between the Godot versions

