### PR TITLE
Fix broken v1.2.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,11 @@ branding:
 runs:
   using: 'composite'
   steps:
+    # FIXME: workaround until will be merged: https://github.com/actions/runner/pull/1684
+    - shell: bash
+      run: |
+        echo "GITHUB_ACTION_PATH: ${GITHUB_ACTION_PATH}"
+        [ -d ./.gdunit4_action ] || (mkdir -p ./.gdunit4_action/ && cp -r $GITHUB_ACTION_PATH/.gdunit4_action/* ./.gdunit4_action/)      
 
     # Determine the actual GdUnit4 version that will be used
     - name: 'Determine GdUnit4 Version'


### PR DESCRIPTION
# Why
The v1.2.0 is broken by error
```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/gdunit4-action-test/gdunit4-action-test/.gdunit4_action/versioning'. Did you forget to run actions/checkout before running your local action?
```


# What
Reading the workaround to copy the sub action files into current git work directory,

