### PR TITLE
GD-92: Fixing broken version compatibility test when using `version: …

### DIFF
--- a/.gdunit4_action/versioning/action.yml
+++ b/.gdunit4_action/versioning/action.yml
@@ -58,6 +58,7 @@ runs:
                 if [[ -n "${gdunit_version}" ]]; then
                     echo -e "\e[92m✓ Found installed GdUnit4 version: ${gdunit_version} \e[0m"
                     echo "version=${gdunit_version}" >> $GITHUB_OUTPUT
+                    echo "GDUNIT_VERSION=${gdunit_version}" >> $GITHUB_ENV
                     exit 0
                 else
                     echo -e "\e[31m✗ Error: Could not extract version from ./addons/gdUnit4/plugin.cfg \e[0m"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -189,6 +189,53 @@ jobs:
           fi
 
 
+  # this tets would run the action against already installed GdUnit4 v5.1.1
+  unit-tests-installed-version:
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      checks: write
+      pull-requests: write
+      statuses: write
+    name: 'action with installed gdUnit4 addon'
+
+    steps:
+      - name: 'Checkout gdUnit4-action'
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: 'Install GdUnit4'
+        shell: bash
+        run: |
+          # Download and install GdUnit4 v5.1.1
+          wget -q https://github.com/MikeSchulze/gdUnit4/archive/refs/tags/v5.1.1.zip
+          mkdir -p addons
+          sudo apt update -y
+          sudo apt install libarchive-tools
+          bsdtar -xf v5.1.1.zip --strip-components=1
+
+      - name: 'Install test project'
+        shell: bash
+        run: |
+          cp -rf .github/workflows/resources/* .
+          
+          ls -lsR addons
+
+      - name: 'Test gdUnit4-action: with installed GdUnit addon'
+        timeout-minutes: 5
+        uses: ./
+        with:
+          godot-version: 4.4.1
+          version: 'installed'
+          paths: |
+            res://tests/
+          timeout: 2
+          publish-report: false
+          report-name: gdUnit4-installed-version
+
+
   unit-tests-custom-working-directory:
     runs-on: ubuntu-24.04
     permissions:
@@ -459,6 +506,7 @@ jobs:
     needs:
       - compatibility-check
       - unit-tests
+      - unit-tests-installed-version
       - unit-tests-custom-working-directory
       - unit-tests-force-godot-mono
       - action-fail-test


### PR DESCRIPTION
…'installed'`

# Why
When using the action and configuring “version” as “installed,” the version check does not work and the action fails.

# What
- adding test to ci-pr to run the action against installed version
- adding missing set of `GDUNIT_VERSION`  


<img width="678" height="292" alt="image" src="https://github.com/user-attachments/assets/6deb29d2-d27b-4ebd-a2d8-27d47b11bf97" />

