### PR TITLE
GD-113: Add support for net10

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -30,9 +30,9 @@ jobs:
       max-parallel: 10
       matrix:
         version: ['v5.1.1']
-        godot-version: ['4.3', '4.4', '4.4.1']
+        godot-version: ['4.4', '4.4.1', '4.5', '4.6']
         godot-status: ['stable']
-        dotnet-version: ['', 'net8.0', 'net9.0']
+        dotnet-version: ['', 'net8.0', 'net9.0', 'net10.0']
         include:
           # V6.0.0
           - version: 'v6.0.0'

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -17,101 +17,39 @@ on:
   schedule:
     - cron: "0 0 * * 6" # At 12:00 AM, only on Saturday
 
+permissions:
+  actions: read
+  contents: read
+  checks: write
+  pull-requests: write
+  statuses: write
+
 concurrency:
   group: ci-dev-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
 
-  unit-tests:
-    runs-on: 'ubuntu-24.04'
-    strategy:
-      fail-fast: false
-      max-parallel: 10
-      matrix:
-        version: ['v5.1.1']
-        godot-version: ['4.4', '4.4.1', '4.5', '4.6']
-        godot-status: ['stable']
-        dotnet-version: ['', 'net8.0', 'net9.0', 'net10.0']
-        include:
-          # V6.0.0
-          - version: 'v6.0.0'
-            godot-version: '4.5'
-            godot-status: 'stable'
-          - version: 'v6.0.0'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net8.0'
-          - version: 'v6.0.0'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net9.0'
-          # Latest
-          - version: 'latest'
-            godot-version: '4.5'
-            godot-status: 'stable'
-          - version: 'latest'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net8.0'
-          - version: 'latest'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net9.0'
+  unit-tests-v5x:
+    uses: ./.github/workflows/shared-unit-tests.yml
+    with:
+      versions: '["v5.1.1"]'
+      godot-versions: '["4.3", "4.4", "4.4.1"]'
+      dotnet-versions: '["", "net8.0"]'
 
-    permissions:
-      actions: read
-      contents: read
-      checks: write
-      pull-requests: write
-      statuses: write
-    name: 'GdUnit4 ${{ matrix.version }} on Godot_${{ matrix.godot-version }} ${{ matrix.dotnet-version }}'
+  unit-tests-v61:
+    uses: ./.github/workflows/shared-unit-tests.yml
+    with:
+      versions: '["v6.0.0"]'
+      godot-versions: '["4.5", "4.5.1"]'
+      dotnet-versions: '["", "net8.0", "net9.0"]'
 
-    steps:
-      - name: 'Checkout gdUnit4-action'
-        uses: actions/checkout@v6
-        with:
-          lfs: true
-
-      - name: 'Install test project'
-        shell: bash
-        run: |
-          mv -f .github/workflows/resources/* .
-
-      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}'
-        if: ${{ matrix.dotnet-version == '' }}
-        id: test-action
-        timeout-minutes: 5
-        uses: ./
-        with:
-          godot-version: ${{ matrix.godot-version }}
-          godot-status: ${{ matrix.godot-status }}
-          version: ${{ matrix.version }}
-          paths: |
-            res://tests/
-            res://tests-2/
-          timeout: 2
-          publish-report: false
-          report-name: gdUnit4_${{ matrix.version }}_Godot${{ matrix.godot-version }}${{ matrix.dotnet-version }}
-
-      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.dotnet-version }}'
-        if: ${{ matrix.dotnet-version != '' }}
-        env:
-          DOTNET_VERSION: ${{ matrix.dotnet-version }}
-        timeout-minutes: 5
-        uses: ./
-        with:
-          godot-version: ${{ matrix.godot-version }}
-          godot-status: ${{ matrix.godot-status }}
-          godot-net: true
-          dotnet-version: ${{ matrix.dotnet-version }}
-          version: ${{ matrix.version }}
-          paths: 'res://tests/mono'
-          timeout: 2
-          retries: 3 # We have set the number of repetitions to 3 because Godot .Net randomly crashes during C# tests
-
-          publish-report: false
-          report-name: gdUnit4_${{ matrix.version }}_Godot${{ matrix.godot-version }}${{ matrix.dotnet-version }}
+  unit-tests-v62:
+    uses: ./.github/workflows/shared-unit-tests.yml
+    with:
+      versions: '["v6.1.0", "latest"]'
+      godot-versions: '["4.5", "4.5.1", "4.6", "4.6.1", "4.6.2"]'
+      dotnet-versions: '["", "net8.0", "net9.0", "net10.0"]'
 
 
   compatibility-check:
@@ -465,7 +403,9 @@ jobs:
     name: 'Final Results'
     needs:
       - compatibility-check
-      - unit-tests
+      - unit-tests-v5x
+      - unit-tests-v61
+      - unit-tests-v62
       - unit-tests-custom-working-directory
       - unit-tests-force-godot-mono
       - action-fail-test

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       versions: '["v5.1.1"]'
       godot-versions: '["4.3", "4.4", "4.4.1"]'
+      dotnet-versions: '["", "net8.0"]'
       workflow-run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
 
   publish-reports-v61:
@@ -30,6 +31,7 @@ jobs:
     with:
       versions: '["v6.0.0"]'
       godot-versions: '["4.5", "4.5.1"]'
+      dotnet-versions: '["", "net8.0", "net9.0"]'
       workflow-run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
 
   publish-reports-v62:
@@ -37,4 +39,5 @@ jobs:
     with:
       versions: '["v6.1.0", "latest"]'
       godot-versions: '["4.5", "4.5.1", "4.6", "4.6.1", "4.6.2"]'
+      dotnet-versions: '["", "net8.0", "net9.0", "net10.0"]'
       workflow-run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -24,9 +24,9 @@ jobs:
       max-parallel: 10
       matrix:
         gdunit-version: ['v5.1.1']
-        godot-version: ['4.3', '4.4', '4.4.1']
+        godot-version: ['4.4', '4.4.1', '4.5', '4.6']
         godot-status: ['stable']
-        dotnet-version: ['', 'net8.0', 'net9.0']
+        dotnet-version: ['', 'net8.0', 'net9.0', 'net10.0']
         include:
           # V6.0.0
           - gdunit-version: 'v6.0.0'

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -17,79 +17,24 @@ permissions:
   checks: write
 
 jobs:
-  publish-reports:
-    runs-on: ${{ matrix.dotnet-version == 'net7.0' && 'ubuntu-22.04' || 'ubuntu-24.04' }}
-    strategy:
-      fail-fast: false
-      max-parallel: 10
-      matrix:
-        gdunit-version: ['v5.1.1']
-        godot-version: ['4.4', '4.4.1', '4.5', '4.6']
-        godot-status: ['stable']
-        dotnet-version: ['', 'net8.0', 'net9.0', 'net10.0']
-        include:
-          # V6.0.0
-          - gdunit-version: 'v6.0.0'
-            godot-version: '4.5'
-            godot-status: 'stable'
-          - gdunit-version: 'v6.0.0'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net8.0'
-          - gdunit-version: 'v6.0.0'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net9.0'
-          # Latest
-          - gdunit-version: 'latest'
-            godot-version: '4.5'
-            godot-status: 'stable'
-          - gdunit-version: 'latest'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net8.0'
-          - gdunit-version: 'latest'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net9.0'
 
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          sparse-checkout: .github
+  publish-reports-v5x:
+    uses: ./.github/workflows/shared-publish-report.yml
+    with:
+      versions: '["v5.1.1"]'
+      godot-versions: '["4.3", "4.4", "4.4.1"]'
+      workflow-run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: artifact_gdUnit4_${{ matrix.gdunit-version }}_Godot${{ matrix.godot-version }}${{ matrix.dotnet-version }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: godot-gdunit-labs/gdUnit4-action
-          run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
+  publish-reports-v61:
+    uses: ./.github/workflows/shared-publish-report.yml
+    with:
+      versions: '["v6.0.0"]'
+      godot-versions: '["4.5", "4.5.1"]'
+      workflow-run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}
 
-      - name: 'Publish Test Results'
-        if: ${{ matrix.dotnet-version == '' }}
-        uses: dorny/test-reporter@v3
-        with:
-          name: report_gdUnit4_${{ matrix.gdunit-version }}-Godot${{ matrix.godot-version }}
-          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363
-          # We do the download manually on step `Download artifacts`
-          #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.gdotnet-version }}
-          path: './home/runner/work/gdUnit4-action/gdUnit4-action/reports/**/results.xml'
-          reporter: java-junit
-          fail-on-error: 'false'
-          fail-on-empty: 'false'
-          use-actions-summary: 'false'
-
-      - name: 'Publish Test Adapter Results'
-        if: ${{ matrix.dotnet-version != '' }}
-        uses: dorny/test-reporter@v3
-        with:
-          name: report_gdUnit4_${{ matrix.gdunit-version }}-Godot${{ matrix.godot-version }}-${{ matrix.dotnet-version }}
-          # using artifact to download is broken since download-artifact@v4 see https://github.com/dorny/test-reporter/issues/363
-          # We do the download manually on step `Download artifacts`
-          #artifact: artifact_gdUnit4_Godot${{ matrix.godot-version }}-${{ matrix.godot-status }}${{ matrix.gdotnet-version }}
-          path: './home/runner/work/gdUnit4-action/gdUnit4-action/reports/*.xml'
-          reporter: dotnet-trx
-          fail-on-error: 'false'
-          fail-on-empty: 'false'
-          use-actions-summary: 'false'
+  publish-reports-v62:
+    uses: ./.github/workflows/shared-publish-report.yml
+    with:
+      versions: '["v6.1.0", "latest"]'
+      godot-versions: '["4.5", "4.5.1", "4.6", "4.6.1", "4.6.2"]'
+      workflow-run-id: ${{ github.event.inputs.workflow_run_id || github.event.workflow_run.id }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -23,9 +23,9 @@ jobs:
       max-parallel: 10
       matrix:
         version: ['v5.1.1']
-        godot-version: ['4.3', '4.4', '4.4.1']
+        godot-version: ['4.4', '4.4.1', '4.5', '4.6']
         godot-status: ['stable']
-        dotnet-version: ['', 'net8.0', 'net9.0']
+        dotnet-version: ['', 'net8.0', 'net9.0', 'net10.0']
         include:
           # V6.0.0
           - version: 'v6.0.0'

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -10,101 +10,39 @@ on:
   workflow_dispatch:
 
 
+permissions:
+  actions: read
+  contents: read
+  checks: write
+  pull-requests: write
+  statuses: write
+
 concurrency:
   group: ci-pr-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
 
-  unit-tests:
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      max-parallel: 10
-      matrix:
-        version: ['v5.1.1']
-        godot-version: ['4.4', '4.4.1', '4.5', '4.6']
-        godot-status: ['stable']
-        dotnet-version: ['', 'net8.0', 'net9.0', 'net10.0']
-        include:
-          # V6.0.0
-          - version: 'v6.0.0'
-            godot-version: '4.5'
-            godot-status: 'stable'
-          - version: 'v6.0.0'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net8.0'
-          - version: 'v6.0.0'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net9.0'
-          # Latest
-          - version: 'latest'
-            godot-version: '4.5'
-            godot-status: 'stable'
-          - version: 'latest'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net8.0'
-          - version: 'latest'
-            godot-version: '4.5'
-            godot-status: 'stable'
-            dotnet-version: 'net9.0'
+  unit-tests-v5x:
+    uses: ./.github/workflows/shared-unit-tests.yml
+    with:
+      versions: '["v5.1.1"]'
+      godot-versions: '["4.3", "4.4", "4.4.1"]'
+      dotnet-versions: '["", "net8.0"]'
 
-    permissions:
-      actions: read
-      contents: read
-      checks: write
-      pull-requests: write
-      statuses: write
-    name: 'GdUnit4 ${{ matrix.version }} on Godot_${{ matrix.godot-version }} ${{ matrix.dotnet-version }}'
+  unit-tests-v61:
+    uses: ./.github/workflows/shared-unit-tests.yml
+    with:
+      versions: '["v6.0.0"]'
+      godot-versions: '["4.5", "4.5.1"]'
+      dotnet-versions: '["", "net8.0", "net9.0"]'
 
-    steps:
-      - name: 'Checkout gdUnit4-action'
-        uses: actions/checkout@v6
-        with:
-          lfs: true
-
-      - name: 'Install test project'
-        shell: bash
-        run: |
-          mv -f .github/workflows/resources/* .
-
-      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}'
-        if: ${{ matrix.dotnet-version == '' }}
-        id: test-action
-        timeout-minutes: 5
-        uses: ./
-        with:
-          godot-version: ${{ matrix.godot-version }}
-          godot-status: ${{ matrix.godot-status }}
-          version: ${{ matrix.version }}
-          paths: |
-            res://tests/
-            res://tests-2/
-          timeout: 2
-          publish-report: false
-          report-name: gdUnit4_${{ matrix.version }}_Godot${{ matrix.godot-version }}${{ matrix.dotnet-version }}
-
-      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.dotnet-version }}'
-        if: ${{ matrix.dotnet-version != '' }}
-        env:
-          DOTNET_VERSION: ${{ matrix.dotnet-version }}
-        timeout-minutes: 5
-        uses: ./
-        with:
-          godot-version: ${{ matrix.godot-version }}
-          godot-status: ${{ matrix.godot-status }}
-          godot-net: true
-          dotnet-version: ${{ matrix.dotnet-version }}
-          version: ${{ matrix.version }}
-          paths: 'res://tests/mono'
-          timeout: 2
-          retries: 3 # We have set the number of repetitions to 3 because Godot .Net randomly crashes during C# tests
-
-          publish-report: false
-          report-name: gdUnit4_${{ matrix.version }}_Godot${{ matrix.godot-version }}${{ matrix.dotnet-version }}
+  unit-tests-v62:
+    uses: ./.github/workflows/shared-unit-tests.yml
+    with:
+      versions: '["v6.1.0", "latest"]'
+      godot-versions: '["4.5", "4.5.1", "4.6", "4.6.1", "4.6.2"]'
+      dotnet-versions: '["", "net8.0", "net9.0", "net10.0"]'
 
 
   compatibility-check:
@@ -505,7 +443,9 @@ jobs:
     name: 'Final Results'
     needs:
       - compatibility-check
-      - unit-tests
+      - unit-tests-v5x
+      - unit-tests-v61
+      - unit-tests-v62
       - unit-tests-installed-version
       - unit-tests-custom-working-directory
       - unit-tests-force-godot-mono

--- a/.github/workflows/shared-publish-report.yml
+++ b/.github/workflows/shared-publish-report.yml
@@ -1,0 +1,68 @@
+name: publish-report
+
+on:
+  workflow_call:
+    inputs:
+      versions:
+        description: 'JSON array of gdUnit4 versions to publish reports for'
+        type: string
+        required: true
+      godot-versions:
+        description: 'JSON array of Godot versions to publish reports for'
+        type: string
+        required: true
+      dotnet-versions:
+        description: 'JSON array of dotnet versions (empty string for GDScript-only)'
+        type: string
+        default: '["", "net8.0", "net9.0", "net10.0"]'
+      workflow-run-id:
+        description: 'ID of the workflow run to download artifacts from'
+        type: string
+        required: true
+
+jobs:
+  publish-reports:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        gdunit-version: ${{ fromJSON(inputs.versions) }}
+        godot-version: ${{ fromJSON(inputs.godot-versions) }}
+        godot-status: ['stable']
+        dotnet-version: ${{ fromJSON(inputs.dotnet-versions) }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: artifact_gdUnit4_${{ matrix.gdunit-version }}_Godot${{ matrix.godot-version }}${{ matrix.dotnet-version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: godot-gdunit-labs/gdUnit4-action
+          run-id: ${{ inputs.workflow-run-id }}
+
+      - name: 'Publish Test Results'
+        if: ${{ matrix.dotnet-version == '' }}
+        uses: dorny/test-reporter@v3
+        with:
+          name: report_gdUnit4_${{ matrix.gdunit-version }}-Godot${{ matrix.godot-version }}
+          path: './home/runner/work/gdUnit4-action/gdUnit4-action/reports/**/results.xml'
+          reporter: java-junit
+          fail-on-error: 'false'
+          fail-on-empty: 'false'
+          use-actions-summary: 'false'
+
+      - name: 'Publish Test Adapter Results'
+        if: ${{ matrix.dotnet-version != '' }}
+        uses: dorny/test-reporter@v3
+        with:
+          name: report_gdUnit4_${{ matrix.gdunit-version }}-Godot${{ matrix.godot-version }}-${{ matrix.dotnet-version }}
+          path: './home/runner/work/gdUnit4-action/gdUnit4-action/reports/*.xml'
+          reporter: dotnet-trx
+          fail-on-error: 'false'
+          fail-on-empty: 'false'
+          use-actions-summary: 'false'

--- a/.github/workflows/shared-unit-tests.yml
+++ b/.github/workflows/shared-unit-tests.yml
@@ -1,0 +1,82 @@
+name: unit-tests
+
+on:
+  workflow_call:
+    inputs:
+      versions:
+        description: 'JSON array of gdUnit4 versions to test'
+        type: string
+        required: true
+      godot-versions:
+        description: 'JSON array of Godot versions to test against'
+        type: string
+        required: true
+      dotnet-versions:
+        description: 'JSON array of dotnet versions to test (empty string for GDScript-only)'
+        type: string
+        default: '["", "net8.0", "net9.0", "net10.0"]'
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        version: ${{ fromJSON(inputs.versions) }}
+        godot-version: ${{ fromJSON(inputs.godot-versions) }}
+        godot-status: ['stable']
+        dotnet-version: ${{ fromJSON(inputs.dotnet-versions) }}
+
+    permissions:
+      actions: read
+      contents: read
+      checks: write
+      pull-requests: write
+      statuses: write
+    name: 'GdUnit4 ${{ matrix.version }} on Godot_${{ matrix.godot-version }} ${{ matrix.dotnet-version }}'
+
+    steps:
+      - name: 'Checkout gdUnit4-action'
+        uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: 'Install test project'
+        shell: bash
+        run: |
+          mv -f .github/workflows/resources/* .
+
+      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}'
+        if: ${{ matrix.dotnet-version == '' }}
+        id: test-action
+        timeout-minutes: 5
+        uses: ./
+        with:
+          godot-version: ${{ matrix.godot-version }}
+          godot-status: ${{ matrix.godot-status }}
+          version: ${{ matrix.version }}
+          paths: |
+            res://tests/
+            res://tests-2/
+          timeout: 2
+          publish-report: false
+          report-name: gdUnit4_${{ matrix.version }}_Godot${{ matrix.godot-version }}${{ matrix.dotnet-version }}
+
+      - name: 'Test gdUnit4-action: GdUnit4 ${{ matrix.version }} - Godot_${{ matrix.godot-version }}-${{ matrix.dotnet-version }}'
+        if: ${{ matrix.dotnet-version != '' }}
+        env:
+          DOTNET_VERSION: ${{ matrix.dotnet-version }}
+        timeout-minutes: 5
+        uses: ./
+        with:
+          godot-version: ${{ matrix.godot-version }}
+          godot-status: ${{ matrix.godot-status }}
+          godot-net: true
+          dotnet-version: ${{ matrix.dotnet-version }}
+          version: ${{ matrix.version }}
+          paths: 'res://tests/mono'
+          timeout: 2
+          retries: 3 # We have set the number of repetitions to 3 because Godot .Net randomly crashes during C# tests
+          publish-report: false
+          report-name: gdUnit4_${{ matrix.version }}_Godot${{ matrix.godot-version }}${{ matrix.dotnet-version }}

--- a/action.yml
+++ b/action.yml
@@ -190,7 +190,7 @@ runs:
       if: ${{ steps.version_check.outcome == 'success' && !cancelled() && (inputs.godot-net == 'true' || inputs.godot-force-mono == 'true') }}
       shell: bash
       run: |
-        sdk_version=$(echo "${{ inputs.dotnet-version }}" | sed 's/^net\([0-9]\.[0-9]\)$/\1.x/')
+        sdk_version=$(echo "${{ inputs.dotnet-version }}" | sed 's/^net\([0-9][0-9]*\.[0-9][0-9]*\)$/\1.x/')
         echo "SDK_VERSION=$sdk_version" >> "$GITHUB_ENV"
         echo "Using .NET version: '$sdk_version'"
 


### PR DESCRIPTION
# Why
When dotnet-version is set to net10.0, the action fails because the sed regex used to extract the SDK version only matches single-digit major versions ([0-9]), leaving net10.0 untransformed and passing it directly to actions/setup-dotnet, which rejects it:

```
  Error: The 'dotnet-version' was supplied in invalid format: net10.0! Supported syntax: A.B.C, A.B, A.B.x, A, A.x, A.B.Cxx
```

# What

Update the sdk version regex in action.yml to support multi-digit major versions:

Test matrix restructure — split the single matrix into three jobs with explicit Godot and .NET version ranges per gdUnit4 release line:

| Job | gdUnit4 | Godot | .NET |
|---|---|---|---|
| `unit-tests-v5x` | v5.1.1 | 4.3, 4.4, 4.4.1 | net8 |
| `unit-tests-v61` | v6.0.0 | 4.5, 4.5.1 | net8, net9 |
| `unit-tests-v62` | v6.1.0, latest | 4.5, 4.5.1, 4.6, 4.6.1, 4.6.2 | net8, net9, net10 |

Reusable workflows — extracted the unit-test and publish-report jobs into `shared-unit-tests.yml` and `shared-publish-report.yml` to avoid duplication across `ci-pr.yml` and `ci-master.yml`.
